### PR TITLE
Actually execute all proofs as part of CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+      - name: run testProofs.sh
+        run: |
+          ./testProofs.sh

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/__pycache__/
 dist
 proofOutput.txt
+.venv

--- a/testProofs.sh
+++ b/testProofs.sh
@@ -3,22 +3,10 @@
 RED='\033[0;31m'
 NC='\033[0m' # No Color
 
-proofs="examples/Proofs/SymEnc/OTUC=>OTS.proof
-examples/Proofs/SymEnc/CPA$=>CPA.proof
-examples/Proofs/SymEnc/GeneralDoubleOTUC.proof
-examples/Proofs/SymEnc/OTUC=>DoubleOTUC.proof
-examples/Book/2/2_13.proof
-examples/Book/5/5_3.proof
-examples/Book/5/5_5_TriplingPRGSecure.proof
-examples/Proofs/PubEnc/OTS=>CPA.proof
-examples/Proofs/PubEnc/Hybrid.proof
-examples/Proofs/SymEnc/EncryptThenMACCCA.proof
-examples/Proofs/SymEnc/DoubleCPA$.proof";
-
 rm proofOutput.txt
 touch proofOutput.txt
 succeeded=true
-for proof in $proofs; do
+for proof in examples/**/**/**.proof; do
 	echo "Running proof $proof"
 	echo "========STARTING PROOF $proof========" >> proofOutput.txt
 	python3 -m proof_frog prove $proof $1 >> proofOutput.txt


### PR DESCRIPTION
Hi, I noticed that not all of the proof examples are being parsed and checked as part of regular CI, I created a workflow to do so - several are broken:

<img width="825" alt="image" src="https://github.com/ProofFrog/ProofFrog/assets/552961/b058a306-35c3-40f1-8831-1c6efb45ca2a">
