### PR TITLE
Restructure engine slightly, allow definitions via method call

### DIFF
--- a/proof_frog/frog_ast.py
+++ b/proof_frog/frog_ast.py
@@ -662,7 +662,7 @@ class Induction(ASTNode):
         name: str,
         start: Expression,
         end: Expression,
-        steps: list[Step | StepAssumption],
+        steps: list[Step | StepAssumption | Induction],
     ):
         self.name = name
         self.start = start

--- a/proof_frog/proof_engine.py
+++ b/proof_frog/proof_engine.py
@@ -31,6 +31,8 @@ class ProofEngine:
 
         self.verbose = verbose
         self.step_assumptions: list[ProcessedAssumption] = []
+        self.variables: dict[str, Symbol | frog_ast.Expression] = {}
+        self.method_lookup: MethodLookup = {}
 
     def add_definition(self, name: str, root: frog_ast.Root) -> None:
         self.definition_namespace[name] = root
@@ -38,8 +40,6 @@ class ProofEngine:
     def prove(self, proof_file: frog_ast.ProofFile) -> None:
         for game in proof_file.helpers:
             self.definition_namespace[game.name] = game
-
-        self.variables: dict[str, Symbol | frog_ast.Expression] = {}
 
         # Here, we are substituting the lets with the parameters they are given
         for let in proof_file.lets:
@@ -634,7 +634,7 @@ class ProofEngine:
         return new_game
 
     def get_method_lookup(self) -> None:
-        self.method_lookup: MethodLookup = {}
+        self.method_lookup = {}
 
         for name, node in self.proof_namespace.items():
             if isinstance(node, frog_ast.Scheme):

--- a/proof_frog/proof_frog.py
+++ b/proof_frog/proof_frog.py
@@ -1,6 +1,6 @@
 import sys
-from colorama import init
 import os
+from colorama import init
 from . import frog_parser
 from . import frog_ast
 from . import proof_engine

--- a/proof_frog/proof_frog.py
+++ b/proof_frog/proof_frog.py
@@ -32,8 +32,8 @@ def main() -> None:
             case _:
                 usage()
     elif argv[1] == "prove":
-        engine = proof_engine.ProofEngine(argv[2], len(argv) > 3 and argv[3] == "-v")
-        engine.prove()
+        engine = proof_engine.ProofEngine(len(argv) > 3 and argv[3] == "-v")
+        engine.prove(argv[2])
     else:
         usage()
 

--- a/proof_frog/proof_frog.py
+++ b/proof_frog/proof_frog.py
@@ -1,6 +1,8 @@
 import sys
 from colorama import init
+import os
 from . import frog_parser
+from . import frog_ast
 from . import proof_engine
 
 
@@ -33,9 +35,32 @@ def main() -> None:
                 usage()
     elif argv[1] == "prove":
         engine = proof_engine.ProofEngine(len(argv) > 3 and argv[3] == "-v")
-        engine.prove(argv[2])
+
+        proof_file = frog_parser.parse_proof_file(argv[2])
+        for imp in proof_file.imports:
+            file_type = _get_file_type(imp.filename)
+            root: frog_ast.Root
+            match file_type:
+                case frog_ast.FileType.PRIMITIVE:
+                    root = frog_parser.parse_primitive_file(imp.filename)
+                case frog_ast.FileType.SCHEME:
+                    root = frog_parser.parse_scheme_file(imp.filename)
+                case frog_ast.FileType.GAME:
+                    root = frog_parser.parse_game_file(imp.filename)
+                case frog_ast.FileType.PROOF:
+                    raise TypeError("Cannot import proofs")
+
+            name = imp.rename if imp.rename else root.get_export_name()
+            engine.add_definition(name, root)
+
+        engine.prove(proof_file)
     else:
         usage()
+
+
+def _get_file_type(file_name: str) -> frog_ast.FileType:
+    extension: str = os.path.splitext(file_name)[1].strip(".")
+    return frog_ast.FileType(extension)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There are some intermingling of concerns in the engine that should be separated for good software practices.

- The engine previously has been making parsing calls for the proof file AST. SRP states this is more than one concern and should be done elsewhere.
- Refactoring so imported definitions can be loaded in via method calls will allow users to specify definitions in different code blocks when we make this jupyter server.
- We now take in the proof AST in the prove method, so that multiple proofs could be performed with the same imported definitions

This is purely a refactoring and has no effect on engine behaviour. 