### PR TITLE
Fix RedundantCopyTransformer incorrectly blocking valid substitutions

### DIFF
--- a/proof_frog/visitors.py
+++ b/proof_frog/visitors.py
@@ -188,23 +188,18 @@ class RedundantCopyTransformer(BlockTransformer):
                         and node.var.name == copy_name
                     )
 
-                def original_used(original_name: str, node: frog_ast.ASTNode) -> bool:
-                    return (
-                        isinstance(node, frog_ast.Variable)
-                        and node.name == original_name
-                    )
-
                 remaining_block = frog_ast.Block(
                     copy.deepcopy(block.statements[index + 1 :])
                 )
                 was_written = SearchVisitor[frog_ast.Variable](
                     functools.partial(written_to, copy_name)
                 ).visit(remaining_block)
-                used_again = SearchVisitor[frog_ast.Variable](
-                    functools.partial(original_used, original_name)
+                original_reassigned = SearchVisitor[frog_ast.Variable](
+                    functools.partial(written_to, original_name)
                 ).visit(remaining_block)
-                # If it was used again, just move on. This ain't gonna work.
-                if was_written or used_again:
+                # If the copy was reassigned, or the original was reassigned
+                # (making the substitution unsafe), skip.
+                if was_written or original_reassigned:
                     continue
 
                 def copy_used(copy_name: str, node: frog_ast.ASTNode) -> bool:

--- a/tests/test_redundant_copies.py
+++ b/tests/test_redundant_copies.py
@@ -40,6 +40,24 @@ from proof_frog import visitors, frog_parser
             }
             """,
         ),
+        # Douglas' test case
+        (
+            """
+            BitString<lambda + stretch> Eval(BitString<lambda> k, BitString<lambda + stretch> m) { 
+                BitString<lambda + stretch> v1 = G.evaluate(k);
+                BitString<lambda + stretch> v2 = v1;
+                BitString<lambda + stretch> v3 = v2 + m;
+                return v1 + v3;
+            }
+            """,
+            """
+            BitString<lambda + stretch> Eval(BitString<lambda> k, BitString<lambda + stretch> m) { 
+                BitString<lambda + stretch> v1 = G.evaluate(k);
+                BitString<lambda + stretch> v3 = v1 + m;
+                return v1 + v3;
+            }
+            """,
+        ),
         # Many chained together
         (
             """


### PR DESCRIPTION
I ran into a bug involving the test case shown in the attached test file.  

Claude proposed the attached fix, with the following summary of its reasoning:

`RedundantCopyTransformer` failed to eliminate a redundant copy `b = a` whenever the original variable `a` appeared anywhere in the remaining block — including innocent reads. The guard condition used `original_used`, which matched any read of `a`, but the actual safety requirement is that `a` must not be reassigned after the copy (which would cause `a` and `b` to diverge). Reads of `a` are harmless and should not block the transformation.

Root cause: The `used_again` check tested `isinstance(node, frog_ast.Variable) and node.name == original_name`, catching all reads of the original. The correct check reuses the existing `written_to` predicate on `original_name` to detect reassignment.

Example that was incorrectly left untransformed:

```
v1 = G.evaluate(k);
v2 = v1;          // redundant copy
v3 = v2 + m;
return v1 + v3;   // v1 read here caused the bug
```

After the fix this correctly becomes:
```
v1 = G.evaluate(k);
v3 = v1 + m;
return v1 + v3;
```
A regression test covering this case is added.