### PR TITLE
Add expand/collapse all buttons to file explorer sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,5 @@ The output from the `docker run` command will contain a `localhost:8888` URL con
 We acknowledge the support of the Natural Sciences and Engineering Research Council of Canada (NSERC).
 
 Nous remercions le Conseil de recherches en sciences naturelles et en génie du Canada (CRSNG) de son soutien.
+
+Includes icons from the [vscode-codicons](https://github.com/microsoft/vscode-codicons) projects.

--- a/proof_frog/web/app.js
+++ b/proof_frog/web/app.js
@@ -4,7 +4,7 @@
 import { state, applyTheme, btnSave, btnParse, btnProve, btnTheme } from './state.js';
 import './cm-mode.js';
 import { saveFile, runCommand, updateToolbar } from './editor.js';
-import { loadFileTree } from './file-tree.js';
+import { loadFileTree, collapseAll, expandAll } from './file-tree.js';
 import { updateWizardPanel, closeWizardModal, createGameFromWizard } from './wizard.js';
 import { updateGameHopsPanel } from './game-hops.js';
 import './resize.js';
@@ -18,6 +18,8 @@ document.getElementById("output-close").addEventListener("click", () => {
   document.getElementById("output-pane").classList.remove("visible");
 });
 btnTheme.addEventListener("click", () => applyTheme(!state.darkMode));
+document.getElementById("btn-collapse-all").addEventListener("click", collapseAll);
+document.getElementById("btn-expand-all").addEventListener("click", expandAll);
 
 document.getElementById("wizard-modal-close").addEventListener("click", closeWizardModal);
 document.getElementById("wizard-modal-cancel").addEventListener("click", closeWizardModal);

--- a/proof_frog/web/file-tree.js
+++ b/proof_frog/web/file-tree.js
@@ -3,6 +3,20 @@
 import { state, fileTreeEl, dirLabel, apiFetch } from './state.js';
 import { openFile } from './editor.js';
 
+export function collapseAll() {
+  fileTreeEl.querySelectorAll(".tree-dir").forEach(dir => {
+    dir.classList.add("collapsed");
+    dir.querySelector(":scope > .tree-item > .icon").textContent = "\u25B6";
+  });
+}
+
+export function expandAll() {
+  fileTreeEl.querySelectorAll(".tree-dir").forEach(dir => {
+    dir.classList.remove("collapsed");
+    dir.querySelector(":scope > .tree-item > .icon").textContent = "\u25BC";
+  });
+}
+
 function makeIconNamePair(iconText, nameText) {
   const icon = document.createElement("span");
   icon.className = "icon";
@@ -17,11 +31,11 @@ export function buildTree(node, depth) {
   const el = document.createElement("div");
 
   if (node.type === "directory") {
-    el.className = "tree-dir";
+    el.className = "tree-dir collapsed";
     const header = document.createElement("div");
     header.className = "tree-item";
     header.style.paddingLeft = `${8 + depth * 14}px`;
-    const { icon, name } = makeIconNamePair("\u25BC", node.name);
+    const { icon, name } = makeIconNamePair("\u25B6", node.name);
     header.appendChild(icon);
     header.appendChild(name);
     header.addEventListener("click", () => {

--- a/proof_frog/web/index.html
+++ b/proof_frog/web/index.html
@@ -28,7 +28,7 @@
   </div>
   <div id="main">
     <div id="sidebar">
-      <div id="sidebar-header">Explorer</div>
+      <div id="sidebar-header"><span>Explorer</span><span id="sidebar-header-buttons"><button id="btn-expand-all" title="Expand All"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="currentColor" d="M15 6v5c0 2.21-1.79 4-4 4H6c-.74 0-1.38-.4-1.73-1H11c1.65 0 3-1.35 3-3V4.27c.6.35 1 .99 1 1.73m-4 7H4c-1.103 0-2-.897-2-2V4c0-1.103.897-2 2-2h7c1.103 0 2 .897 2 2v7c0 1.103-.897 2-2 2m-7-1h7c.551 0 1-.448 1-1V4c0-.551-.449-1-1-1H4c-.551 0-1 .449-1 1v7c0 .552.449 1 1 1m5.5-5H8V5.5a.5.5 0 0 0-1 0V7H5.5a.5.5 0 0 0 0 1H7v1.5a.5.5 0 0 0 1 0V8h1.5a.5.5 0 0 0 0-1"/></svg></button><button id="btn-collapse-all" title="Collapse All"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><g fill="currentColor"><path d="M14 4.27c.6.35 1 .99 1 1.73v5c0 2.21-1.79 4-4 4H6c-.74 0-1.38-.4-1.73-1H11c1.65 0 3-1.35 3-3zM9.5 7a.5.5 0 0 1 0 1h-4a.5.5 0 0 1 0-1z"/><path fill-rule="evenodd" d="M11 2c1.103 0 2 .897 2 2v7c0 1.103-.897 2-2 2H4c-1.103 0-2-.897-2-2V4c0-1.103.897-2 2-2zM4 3c-.551 0-1 .449-1 1v7c0 .552.449 1 1 1h7c.551 0 1-.448 1-1V4c0-.551-.449-1-1-1z" clip-rule="evenodd"/></g></svg></button></span></div>
       <div id="file-tree"></div>
       <div id="game-hops-panel">
         <div id="inner-resize-handle"></div>

--- a/proof_frog/web/style.css
+++ b/proof_frog/web/style.css
@@ -78,10 +78,19 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
 }
 #sidebar-resize-handle:hover, #sidebar-resize-handle.dragging { background: var(--accent2); }
 #sidebar-header {
+  display: flex; align-items: center; justify-content: space-between;
   padding: 6px 10px; font-size: 11px; font-weight: 600;
   text-transform: uppercase; color: var(--text-dim); letter-spacing: 0.08em;
   border-bottom: 1px solid var(--border); flex-shrink: 0;
 }
+#sidebar-header-buttons { display: flex; gap: 2px; }
+#sidebar-header-buttons button {
+  background: none; border: none; color: var(--text-dim); cursor: pointer;
+  font-size: 10px; padding: 2px; border-radius: 3px; line-height: 0;
+  display: flex; align-items: center; justify-content: center;
+}
+#sidebar-header-buttons button svg { width: 14px; height: 14px; }
+#sidebar-header-buttons button:hover { color: var(--text); background: var(--bg3); }
 #file-tree { flex: 1; overflow-y: auto; padding: 4px 0; }
 .tree-item { display: flex; align-items: center; cursor: pointer; padding: 2px 8px; user-select: none; }
 .tree-item:hover { background: var(--bg3); }


### PR DESCRIPTION
Adds two icon buttons (using vscode-codicons SVGs) to the Explorer
header for expanding and collapsing all directories at once.
Directories now start collapsed on page load.

Co-Authored-By: Claude <noreply@anthropic.com>
