### PR TITLE
Add --json flag to CLI commands for structured output

### DIFF
--- a/proof_frog/mcp_server.py
+++ b/proof_frog/mcp_server.py
@@ -20,24 +20,22 @@ Then register it in .claude/settings.json:
 
 # pylint: disable=duplicate-code  # mcp_server shares return-dict patterns with web_server by design
 from __future__ import annotations
-import io
 import os
 import tempfile
-from contextlib import redirect_stdout, redirect_stderr
 from pathlib import Path
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP  # pylint: disable=import-error
 
-from . import frog_parser, semantic_analysis
+from . import frog_parser
 from . import describe as describe_module
 from .web_server import (
     _capture_parse,
+    _capture_check as _capture_check_impl,
     _capture_prove,
     _capture_inline,
     _build_minimal_proof,
     _build_tree,
-    _strip_ansi,
 )
 
 mcp: FastMCP = FastMCP(
@@ -168,20 +166,8 @@ def check(path: str) -> dict[str, Any]:
     More thorough than parse — catches type mismatches, undefined names,
     signature mismatches between Left/Right games, etc.
     """
-    abs_path = _safe_resolve(path)
-    buf = io.StringIO()
-    try:
-        root = frog_parser.parse_file(abs_path)
-        with redirect_stdout(buf), redirect_stderr(buf):
-            semantic_analysis.check_well_formed(root, abs_path, allowed_root=_directory)
-        return {"output": f"{abs_path} is well-formed.", "success": True}
-    except (frog_parser.ParseError, FileNotFoundError) as e:
-        return {"output": str(e), "success": False}
-    except semantic_analysis.FailedTypeCheck:
-        msg = _strip_ansi(buf.getvalue()) or "Type check failed."
-        return {"output": msg, "success": False}
-    except Exception as e:  # pylint: disable=broad-except
-        return {"output": f"Error: {e}", "success": False}
+    output, success = _capture_check_impl(_safe_resolve(path), allowed_root=_directory)
+    return {"output": output, "success": success}
 
 
 @mcp.tool()  # type: ignore[misc, untyped-decorator]

--- a/proof_frog/proof_frog.py
+++ b/proof_frog/proof_frog.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import os
 
@@ -18,8 +19,16 @@ def cli() -> None:
 
 @cli.command()
 @click.argument("file")
-def parse(file: str) -> None:
+@click.option("--json", "-j", "json_output", is_flag=True, help="Output JSON.")
+def parse(file: str, json_output: bool) -> None:
     """Parse a FrogLang file and print its AST."""
+    if json_output:
+        # pylint: disable=import-outside-toplevel
+        from .web_server import _capture_parse
+
+        output, success = _capture_parse(file)
+        click.echo(json.dumps({"output": output, "success": success}))
+        return
     try:
         root = frog_parser.parse_file(file)
         print(root)
@@ -33,8 +42,16 @@ def parse(file: str) -> None:
 
 @cli.command()
 @click.argument("file")
-def check(file: str) -> None:
+@click.option("--json", "-j", "json_output", is_flag=True, help="Output JSON.")
+def check(file: str, json_output: bool) -> None:
     """Type-check and semantically analyze a FrogLang file."""
+    if json_output:
+        # pylint: disable=import-outside-toplevel
+        from .web_server import _capture_check
+
+        output, success = _capture_check(file)
+        click.echo(json.dumps({"output": output, "success": success}))
+        return
     try:
         root = frog_parser.parse_file(file)
     except ValueError:
@@ -53,8 +70,20 @@ def check(file: str) -> None:
 @cli.command()
 @click.argument("file")
 @click.option("-v", "--verbose", is_flag=True, help="Enable verbose output.")
-def prove(file: str, verbose: bool) -> None:
+@click.option("--json", "-j", "json_output", is_flag=True, help="Output JSON.")
+def prove(file: str, verbose: bool, json_output: bool) -> None:
     """Run proof verification on a .proof file."""
+    if json_output:
+        # pylint: disable=import-outside-toplevel
+        from .web_server import _capture_prove
+
+        output, success, hop_results = _capture_prove(file)
+        click.echo(
+            json.dumps(
+                {"output": output, "success": success, "hop_results": hop_results}
+            )
+        )
+        return
     engine = proof_engine.ProofEngine(verbose)
     proof_file: frog_ast.ProofFile
     try:
@@ -92,8 +121,16 @@ def prove(file: str, verbose: bool) -> None:
 
 @cli.command()
 @click.argument("file")
-def describe(file: str) -> None:
+@click.option("--json", "-j", "json_output", is_flag=True, help="Output JSON.")
+def describe(file: str, json_output: bool) -> None:
     """Print a concise interface description of a FrogLang file."""
+    if json_output:
+        # pylint: disable=import-outside-toplevel
+        from .web_server import _capture_describe
+
+        output, success = _capture_describe(file)
+        click.echo(json.dumps({"output": output, "success": success}))
+        return
     # pylint: disable=import-outside-toplevel
     from proof_frog.describe import describe_file
 

--- a/proof_frog/web_server.py
+++ b/proof_frog/web_server.py
@@ -12,7 +12,8 @@ from typing import Any
 
 from flask import Flask, request, jsonify, send_file, send_from_directory
 
-from . import frog_parser, frog_ast, proof_engine
+from . import frog_parser, frog_ast, proof_engine, semantic_analysis
+from . import describe as describe_module
 
 _ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
 
@@ -59,6 +60,33 @@ def _capture_parse(file_path: str) -> tuple[str, bool]:
         return _strip_ansi(buf.getvalue()) + f"\n{e}", False
     except Exception as e:  # pylint: disable=broad-exception-caught
         return _strip_ansi(buf.getvalue()) + f"\nError: {e}", False
+
+
+def _capture_check(file_path: str, allowed_root: str | None = None) -> tuple[str, bool]:
+    buf = io.StringIO()
+    try:
+        root = frog_parser.parse_file(file_path)
+        with redirect_stdout(buf), redirect_stderr(buf):
+            semantic_analysis.check_well_formed(
+                root, file_path, allowed_root=allowed_root
+            )
+        return f"{file_path} is well-formed.", True
+    except (frog_parser.ParseError, FileNotFoundError) as e:
+        return str(e), False
+    except semantic_analysis.FailedTypeCheck:
+        msg = _strip_ansi(buf.getvalue()) or "Type check failed."
+        return msg, False
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        return f"Error: {e}", False
+
+
+def _capture_describe(file_path: str) -> tuple[str, bool]:
+    try:
+        return describe_module.describe_file(file_path), True
+    except (ValueError, frog_parser.ParseError, FileNotFoundError) as e:
+        return str(e), False
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        return f"Error: {e}", False
 
 
 def _get_file_type(file_name: str) -> frog_ast.FileType:

--- a/tests/test_cli_json.py
+++ b/tests/test_cli_json.py
@@ -1,0 +1,107 @@
+"""Tests for the --json CLI output flag."""
+
+import json
+import os
+
+from click.testing import CliRunner
+
+from proof_frog.proof_frog import cli
+
+EXAMPLES = os.path.join(os.path.dirname(__file__), "..", "examples")
+PRIMITIVE = os.path.join(EXAMPLES, "Primitives", "PRG.primitive")
+GAME = os.path.join(EXAMPLES, "Games", "PRG", "PRGSecurity.game")
+PROOF = os.path.join(EXAMPLES, "Book", "5", "5_3.proof")
+
+
+def _run(*args: str) -> tuple[int, dict]:  # type: ignore[type-arg]
+    result = CliRunner().invoke(cli, list(args))
+    return result.exit_code, json.loads(result.output)
+
+
+# ── parse ──────────────────────────────────────────────────────────────
+
+
+def test_parse_json_success() -> None:
+    code, data = _run("parse", "--json", PRIMITIVE)
+    assert code == 0
+    assert data["success"] is True
+    assert "output" in data
+
+
+def test_parse_json_missing_file() -> None:
+    code, data = _run("parse", "--json", "nonexistent.primitive")
+    assert code == 0
+    assert data["success"] is False
+
+
+def test_parse_no_json_missing_file() -> None:
+    result = CliRunner().invoke(cli, ["parse", "nonexistent.primitive"])
+    assert result.exit_code == 1
+
+
+# ── check ──────────────────────────────────────────────────────────────
+
+
+def test_check_json_success() -> None:
+    code, data = _run("check", "--json", PRIMITIVE)
+    assert code == 0
+    assert data["success"] is True
+    assert "well-formed" in data["output"]
+
+
+def test_check_json_missing_file() -> None:
+    code, data = _run("check", "--json", "nonexistent.primitive")
+    assert code == 0
+    assert data["success"] is False
+
+
+def test_check_no_json_missing_file() -> None:
+    result = CliRunner().invoke(cli, ["check", "nonexistent.primitive"])
+    assert result.exit_code == 1
+
+
+# ── prove ──────────────────────────────────────────────────────────────
+
+
+def test_prove_json_success() -> None:
+    code, data = _run("prove", "--json", PROOF)
+    assert code == 0
+    assert data["success"] is True
+    assert isinstance(data["hop_results"], list)
+    assert len(data["hop_results"]) > 0
+    hop = data["hop_results"][0]
+    assert "step_num" in hop
+    assert "valid" in hop
+    assert "kind" in hop
+
+
+def test_prove_json_missing_file() -> None:
+    code, data = _run("prove", "--json", "nonexistent.proof")
+    assert code == 0
+    assert data["success"] is False
+
+
+def test_prove_no_json_missing_file() -> None:
+    result = CliRunner().invoke(cli, ["prove", "nonexistent.proof"])
+    assert result.exit_code == 1
+
+
+# ── describe ───────────────────────────────────────────────────────────
+
+
+def test_describe_json_success() -> None:
+    code, data = _run("describe", "--json", PRIMITIVE)
+    assert code == 0
+    assert data["success"] is True
+    assert len(data["output"]) > 0
+
+
+def test_describe_json_missing_file() -> None:
+    code, data = _run("describe", "--json", "nonexistent.primitive")
+    assert code == 0
+    assert data["success"] is False
+
+
+def test_describe_no_json_missing_file() -> None:
+    result = CliRunner().invoke(cli, ["describe", "nonexistent.primitive"])
+    assert result.exit_code == 1


### PR DESCRIPTION
Add a --json/-j option to the parse, check, prove, and describe CLI commands so they output JSON matching the MCP server's response format. In JSON mode, success/failure is conveyed by the "success" field and the exit code is always 0.

Extract _capture_check and _capture_describe helpers into web_server.py to share logic between the CLI, MCP server, and web server. Refactor the MCP server's check tool to use the shared helper.