### PR TITLE
Show warning modal in web UI for proofs containing induction steps

### DIFF
--- a/proof_frog/mcp_server.py
+++ b/proof_frog/mcp_server.py
@@ -182,7 +182,7 @@ def prove(proof_path: str) -> dict[str, Any]:
     Imports in the proof are resolved relative to the server's working directory.
     Use write_file first to save the proof content to disk, then call prove.
     """
-    output, success, hop_results = _capture_prove(
+    output, success, hop_results, _has_induction = _capture_prove(
         _safe_resolve(proof_path), allowed_root=_directory
     )
     return {"output": output, "success": success, "hop_results": hop_results}

--- a/proof_frog/proof_frog.py
+++ b/proof_frog/proof_frog.py
@@ -77,7 +77,7 @@ def prove(file: str, verbose: bool, json_output: bool) -> None:
         # pylint: disable=import-outside-toplevel
         from .web_server import _capture_prove
 
-        output, success, hop_results = _capture_prove(file)
+        output, success, hop_results, _has_induction = _capture_prove(file)
         click.echo(
             json.dumps(
                 {"output": output, "success": success, "hop_results": hop_results}

--- a/proof_frog/web/app.js
+++ b/proof_frog/web/app.js
@@ -31,6 +31,16 @@ document.querySelectorAll("#wizard-modal-body input.wizard-input").forEach(inp =
   inp.addEventListener("keydown", e => { if (e.key === "Enter") createGameFromWizard(); });
 });
 
+// ── Induction warning modal ──────────────────────────────────────────────
+function closeInductionModal() {
+  document.getElementById("induction-modal").classList.remove("visible");
+}
+document.getElementById("induction-modal-close").addEventListener("click", closeInductionModal);
+document.getElementById("induction-modal-ok").addEventListener("click", closeInductionModal);
+document.getElementById("induction-modal").addEventListener("click", e => {
+  if (e.target === document.getElementById("induction-modal")) closeInductionModal();
+});
+
 // ── Keyboard shortcuts ────────────────────────────────────────────────────────
 
 document.addEventListener("keydown", e => {
@@ -40,8 +50,10 @@ document.addEventListener("keydown", e => {
 
 document.addEventListener("keydown", e => {
   if (e.key === "Escape") {
-    const modal = document.getElementById("wizard-modal");
-    if (modal.classList.contains("visible")) closeWizardModal();
+    const wizard = document.getElementById("wizard-modal");
+    if (wizard.classList.contains("visible")) closeWizardModal();
+    const induction = document.getElementById("induction-modal");
+    if (induction.classList.contains("visible")) closeInductionModal();
   }
 });
 

--- a/proof_frog/web/editor.js
+++ b/proof_frog/web/editor.js
@@ -93,6 +93,11 @@ export function activateTab(path) {
   scrollTabIntoView(path);
   updateGameHopsPanel();
   updateWizardPanel();
+
+  // Show warning modal for proofs containing induction steps
+  if (path.endsWith(".proof") && /\binduction\s*\(/.test(cm.getValue())) {
+    document.getElementById("induction-modal").classList.add("visible");
+  }
 }
 
 // ── Editor factory ────────────────────────────────────────────────────────────

--- a/proof_frog/web/index.html
+++ b/proof_frog/web/index.html
@@ -95,6 +95,22 @@
   </div>
 </div>
 
+<div id="induction-modal" role="dialog" aria-modal="true" aria-labelledby="induction-modal-title">
+  <div id="induction-modal-panel">
+    <div id="induction-modal-header">
+      <span id="induction-modal-title">Warning</span>
+      <button id="induction-modal-close" title="Close">&times;</button>
+    </div>
+    <div id="induction-modal-body">
+      <p>This proof contains induction steps. The web UI does not currently display induction-related elements correctly.</p>
+      <p>For full induction support, please use the command-line interface.</p>
+    </div>
+    <div id="induction-modal-footer">
+      <button id="induction-modal-ok" class="primary">OK</button>
+    </div>
+  </div>
+</div>
+
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/codemirror.min.js" integrity="sha512-6cPYokihlrofMNApz7OXVQNObWjLiKGIBBb7+UB+AuMiRCLKmFKgrwms21sHq3bdFFZWpfHYRJBJvMFMPj1S9g==" crossorigin="anonymous"></script>
 <script src="/static/app.js" type="module"></script>
 </body>

--- a/proof_frog/web/style.css
+++ b/proof_frog/web/style.css
@@ -184,6 +184,45 @@ select.wizard-input { cursor: pointer; }
 #wizard-modal-footer button.primary { border-color: var(--accent2); color: var(--accent2); }
 #wizard-modal-footer button.primary:hover { background: rgba(86,156,214,0.12); }
 
+/* ── Induction warning modal ── */
+#induction-modal {
+  position: fixed; inset: 0; z-index: 1000;
+  background: rgba(0,0,0,0.5);
+  display: none; align-items: center; justify-content: center;
+}
+#induction-modal.visible {
+  display: flex;
+}
+#induction-modal-panel {
+  background: var(--bg2); border: 1px solid var(--border); border-radius: 5px;
+  width: 380px; max-width: 90vw; display: flex; flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+}
+#induction-modal-header {
+  display: flex; align-items: center; padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+#induction-modal-title { flex: 1; font-weight: 600; font-size: 13px; }
+#induction-modal-close {
+  background: none; border: none; color: var(--text-dim); cursor: pointer;
+  font-size: 18px; padding: 0 2px; line-height: 1;
+}
+#induction-modal-close:hover { color: var(--text); }
+#induction-modal-body { padding: 14px; font-size: 12px; line-height: 1.5; color: var(--text); }
+#induction-modal-body p { margin: 0 0 8px; }
+#induction-modal-body p:last-child { margin-bottom: 0; }
+#induction-modal-footer {
+  display: flex; gap: 8px; padding: 10px 14px;
+  border-top: 1px solid var(--border); justify-content: flex-end;
+}
+#induction-modal-footer button {
+  padding: 5px 14px; border: 1px solid var(--border); border-radius: 3px;
+  background: var(--bg3); color: var(--text); cursor: pointer; font-size: 12px;
+}
+#induction-modal-footer button:hover { background: var(--bg2); border-color: var(--accent2); }
+#induction-modal-footer button.primary { border-color: var(--accent2); color: var(--accent2); }
+#induction-modal-footer button.primary:hover { background: rgba(86,156,214,0.12); }
+
 /* ── Editor area ── */
 #editor-area { flex: 1; display: flex; flex-direction: column; overflow: hidden; min-width: 0; }
 

--- a/proof_frog/web_server.py
+++ b/proof_frog/web_server.py
@@ -288,13 +288,17 @@ def _capture_inline(
 
 def _capture_prove(
     file_path: str, allowed_root: str | None = None
-) -> tuple[str, bool, list[dict[str, object]]]:
+) -> tuple[str, bool, list[dict[str, object]], bool]:
     buf = io.StringIO()
     engine = proof_engine.ProofEngine(False)
     proof_succeeded = False
+    has_induction = False
     try:
         with redirect_stdout(buf), redirect_stderr(buf):
             proof_file = frog_parser.parse_proof_file(file_path)
+            has_induction = any(
+                isinstance(step, frog_ast.Induction) for step in proof_file.steps
+            )
 
             for imp in proof_file.imports:
                 imp_path = frog_parser.resolve_import_path(
@@ -325,11 +329,11 @@ def _capture_prove(
             for r in engine.hop_results
             if r.depth == 0 and r.kind != "induction_rollover"
         ]
-        return _strip_ansi(buf.getvalue()), proof_succeeded, hop_results
+        return _strip_ansi(buf.getvalue()), proof_succeeded, hop_results, has_induction
     except (frog_parser.ParseError, FileNotFoundError) as e:
-        return _strip_ansi(buf.getvalue()) + f"\n{e}", False, []
+        return _strip_ansi(buf.getvalue()) + f"\n{e}", False, [], False
     except Exception as e:  # pylint: disable=broad-exception-caught
-        return _strip_ansi(buf.getvalue()) + f"\nError: {e}", False, []
+        return _strip_ansi(buf.getvalue()) + f"\nError: {e}", False, [], False
 
 
 def _build_tree(path: Path, base: Path) -> dict[str, object]:
@@ -444,11 +448,16 @@ def create_app(directory: str) -> Flask:
         if abs_path is None:
             return jsonify({"error": "Invalid path"}), 403
         abs_path.write_text(content, encoding="utf-8")
-        output, success, hop_results = _capture_prove(
+        output, success, hop_results, has_induction = _capture_prove(
             str(abs_path), allowed_root=directory
         )
         return jsonify(
-            {"output": output, "success": success, "hop_results": hop_results}
+            {
+                "output": output,
+                "success": success,
+                "hop_results": hop_results,
+                "has_induction": has_induction,
+            }
         )
 
     @app.route("/api/inline", methods=["POST"])


### PR DESCRIPTION
When a user opens a .proof file that contains induction blocks, the web UI now displays a modal warning that induction-related elements are not currently displayed correctly, and suggests using the CLI instead. The modal appears immediately when the file is activated in a tab.

Also adds has_induction flag to the /api/prove JSON response.