### PR TITLE
Add live Markdown preview to web UI editor

### DIFF
--- a/proof_frog/web/editor.js
+++ b/proof_frog/web/editor.js
@@ -1,7 +1,7 @@
 // ── Editor, tab management, save, parse/prove ─────────────────────────────────
 // CodeMirror is a CDN global loaded before the module entry point.
 
-/* global CodeMirror */
+/* global CodeMirror, marked */
 
 import {
   state,
@@ -129,6 +129,68 @@ export function createEditor(content, onChange, path) {
   return { cm, wrap };
 }
 
+// ── Markdown preview ─────────────────────────────────────────────────────────
+
+function updateMarkdownPreview(path) {
+  const tab = state.tabs.get(path);
+  if (!tab || !tab.previewEl) return;
+  tab.previewEl.innerHTML = marked.parse(tab.cm.getValue());
+}
+
+function setupMarkdownSplit(wrap, cm, content) {
+  wrap.classList.add("md-split-view");
+
+  // Wrap the CodeMirror element in a left pane
+  const cmEl = wrap.querySelector(".CodeMirror");
+  const leftPane = document.createElement("div");
+  leftPane.className = "md-editor-pane";
+  wrap.insertBefore(leftPane, cmEl);
+  leftPane.appendChild(cmEl);
+
+  // Vertical resize handle
+  const handle = document.createElement("div");
+  handle.className = "v-split-handle";
+  wrap.appendChild(handle);
+
+  // Right pane with preview
+  const rightPane = document.createElement("div");
+  rightPane.className = "md-preview-pane";
+  const header = document.createElement("div");
+  header.className = "split-pane-header";
+  header.textContent = "Preview";
+  const preview = document.createElement("div");
+  preview.className = "md-preview";
+  preview.innerHTML = marked.parse(content);
+  rightPane.appendChild(header);
+  rightPane.appendChild(preview);
+  wrap.appendChild(rightPane);
+
+  // Store preview element for live updates (tab not yet in state.tabs, so attach to wrap)
+  wrap._mdPreview = preview;
+
+  // Drag-to-resize
+  let startX, startFlex;
+  handle.addEventListener("mousedown", e => {
+    startX = e.clientX;
+    startFlex = leftPane.getBoundingClientRect().width;
+    handle.classList.add("dragging");
+    function onMove(e) {
+      const totalW = wrap.getBoundingClientRect().width - handle.offsetWidth;
+      const newLeftW = Math.max(100, Math.min(totalW - 100, startFlex + (e.clientX - startX)));
+      leftPane.style.flex = `0 0 ${newLeftW}px`;
+      rightPane.style.flex = "1 1 0";
+      cm.refresh();
+    }
+    function onUp() {
+      handle.classList.remove("dragging");
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+    }
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+  });
+}
+
 // ── Open / close tabs ─────────────────────────────────────────────────────────
 
 export async function openFile(path, name) {
@@ -141,13 +203,21 @@ export async function openFile(path, name) {
   if (data.error) { alert(data.error); return; }
   const content = data.content;
 
+  const isMarkdown = path.endsWith(".md");
+
   const { cm, wrap } = createEditor(content, () => {
     updateTabEl(path);
     if (state.activeTab === path && path.endsWith(".proof")) updateGameHopsPanel();
     if (state.activeTab === path) updateWizardPanel();
+    if (isMarkdown) updateMarkdownPreview(path);
   }, path);
 
-  state.tabs.set(path, { name, savedContent: content, cm, wrap, readonly: false });
+  if (isMarkdown) {
+    setupMarkdownSplit(wrap, cm, content);
+  }
+
+  state.tabs.set(path, { name, savedContent: content, cm, wrap, readonly: false,
+    previewEl: wrap._mdPreview || null });
 
   const tabEl = document.createElement("div");
   tabEl.className = "tab";

--- a/proof_frog/web/index.html
+++ b/proof_frog/web/index.html
@@ -96,6 +96,7 @@
 </div>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.18/codemirror.min.js" integrity="sha512-6cPYokihlrofMNApz7OXVQNObWjLiKGIBBb7+UB+AuMiRCLKmFKgrwms21sHq3bdFFZWpfHYRJBJvMFMPj1S9g==" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/marked/16.3.0/lib/marked.umd.min.js" integrity="sha512-V6rGY7jjOEUc7q5Ews8mMlretz1Vn2wLdMW/qgABLWunzsLfluM0FwHuGjGQ1lc8jO5vGpGIGFE+rTzB+63HdA==" crossorigin="anonymous"></script>
 <script src="/static/app.js" type="module"></script>
 </body>
 </html>

--- a/proof_frog/web/style.css
+++ b/proof_frog/web/style.css
@@ -265,6 +265,46 @@ select.wizard-input { cursor: pointer; }
 }
 .h-split-handle:hover, .h-split-handle.dragging { background: var(--accent2); }
 
+/* ── Markdown split-view ── */
+.editor-wrap.md-split-view { flex-direction: row; }
+.editor-wrap.md-split-view.active { display: flex; }
+.md-editor-pane { flex: 1; display: flex; flex-direction: column; overflow: hidden; min-width: 0; }
+.md-editor-pane .CodeMirror { height: 100%; font-size: 13px; font-family: 'Menlo','Monaco','Consolas',monospace; }
+.md-editor-pane .CodeMirror-scroll { height: 100%; }
+.md-preview-pane { flex: 1; display: flex; flex-direction: column; overflow: hidden; min-width: 0; }
+.md-preview {
+  flex: 1; overflow-y: auto; padding: 16px 24px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 14px; line-height: 1.6; color: var(--text);
+}
+.md-preview h1 { font-size: 1.8em; font-weight: 600; margin: 0.6em 0 0.4em; border-bottom: 1px solid var(--border); padding-bottom: 0.3em; }
+.md-preview h2 { font-size: 1.4em; font-weight: 600; margin: 0.6em 0 0.4em; border-bottom: 1px solid var(--border); padding-bottom: 0.2em; }
+.md-preview h3 { font-size: 1.15em; font-weight: 600; margin: 0.5em 0 0.3em; }
+.md-preview h4, .md-preview h5, .md-preview h6 { font-size: 1em; font-weight: 600; margin: 0.5em 0 0.3em; }
+.md-preview p { margin: 0 0 0.8em; }
+.md-preview ul, .md-preview ol { margin: 0 0 0.8em; padding-left: 2em; }
+.md-preview li { margin: 0.2em 0; }
+.md-preview code {
+  font-family: 'Menlo','Monaco','Consolas',monospace; font-size: 0.9em;
+  background: var(--bg3); padding: 0.15em 0.4em; border-radius: 3px;
+}
+.md-preview pre {
+  background: var(--bg3); padding: 12px 16px; border-radius: 4px;
+  overflow-x: auto; margin: 0 0 0.8em;
+}
+.md-preview pre code { background: none; padding: 0; font-size: 0.85em; }
+.md-preview blockquote {
+  border-left: 3px solid var(--accent2); padding: 0.4em 1em; margin: 0 0 0.8em;
+  color: var(--text-dim);
+}
+.md-preview a { color: var(--accent2); text-decoration: none; }
+.md-preview a:hover { text-decoration: underline; }
+.md-preview table { border-collapse: collapse; margin: 0 0 0.8em; width: 100%; }
+.md-preview th, .md-preview td { border: 1px solid var(--border); padding: 6px 12px; text-align: left; }
+.md-preview th { background: var(--bg3); font-weight: 600; }
+.md-preview hr { border: none; border-top: 1px solid var(--border); margin: 1em 0; }
+.md-preview img { max-width: 100%; }
+
 /* ── Welcome screen ── */
 #welcome {
   position: absolute; inset: 0; display: flex; flex-direction: column;


### PR DESCRIPTION
When a .md file is opened, the editor splits side-by-side with a read-only rendered preview on the right. The preview updates live as the user types. Uses marked.js (from cdnjs CDN) for rendering and includes a draggable resize handle between panes. Styled for both dark and light themes.