### PR TITLE
Fix inline Hop Inspector breaking Game Hops panel and showing Run Proof button

### DIFF
--- a/proof_frog/web/editor.js
+++ b/proof_frog/web/editor.js
@@ -22,7 +22,7 @@ export function updateToolbar() {
   const isVirtual = hasTab && state.activeTab.startsWith(":inline:");
   btnSave.disabled = !hasTab || isVirtual;
   btnParse.disabled = !hasTab || isVirtual;
-  const isProof = hasTab && state.activeTab.endsWith(".proof");
+  const isProof = hasTab && !isVirtual && state.activeTab.endsWith(".proof");
   btnProve.style.display = isProof ? "" : "none";
   btnProve.disabled = !isProof;
 }

--- a/proof_frog/web/game-hops.js
+++ b/proof_frog/web/game-hops.js
@@ -42,9 +42,7 @@ export function updateGameHopsPanel() {
   // Resolve the source .proof path (handles both proof tabs and inline tabs)
   let proofPath = null;
   if (state.activeTab) {
-    if (state.activeTab.endsWith(".proof")) {
-      proofPath = state.activeTab;
-    } else if (state.activeTab.startsWith(":inline:")) {
+    if (state.activeTab.startsWith(":inline:")) {
       // Format: ":inline:STEPINDEX:FILEPATH"
       const withoutPrefix = state.activeTab.slice(":inline:".length);
       const colonPos = withoutPrefix.indexOf(":");
@@ -52,6 +50,8 @@ export function updateGameHopsPanel() {
         const candidate = withoutPrefix.slice(colonPos + 1);
         if (candidate.endsWith(".proof")) proofPath = candidate;
       }
+    } else if (state.activeTab.endsWith(".proof")) {
+      proofPath = state.activeTab;
     }
   }
 


### PR DESCRIPTION
The virtual tab path `:inline:STEP:file.proof` ends with `.proof`, which caused two bugs: (1) updateGameHopsPanel matched it as a proof file path instead of extracting the real path, so the panel showed "No game hops" when viewing the Hop Inspector; (2) updateToolbar treated it as a proof tab, showing the Run Proof button which caused a 500 error when clicked.

Fix by checking for the `:inline:` prefix before the `.proof` suffix in both functions.