### PR TITLE
Highlight error lines in web editor and improve missing-semicolon diagnostics

### DIFF
--- a/proof_frog/frog_parser.py
+++ b/proof_frog/frog_parser.py
@@ -62,6 +62,17 @@ class ParseError(Exception):
         return header
 
 
+def _read_source_lines(source: str) -> list[str]:
+    """Read all lines from *source* (a file path or raw text)."""
+    try:
+        if os.path.isfile(source):
+            with open(source, encoding="utf-8") as f:
+                return f.readlines()
+        return source.splitlines(keepends=True)
+    except OSError:
+        return []
+
+
 def _to_parse_error(
     e: antlr_error.Errors.ParseCancellationException, source: str
 ) -> ParseError:
@@ -80,18 +91,32 @@ def _to_parse_error(
     else:
         msg = "syntax error"
 
+    all_lines = _read_source_lines(source)
+
+    # Heuristic: if the offending token starts a new line and the previous
+    # non-blank line doesn't end with a semicolon, brace, or colon, the
+    # real problem is likely a missing ';' on that previous line.
+    if line >= 2 and token_text and token_text != "<EOF>":
+        prev_idx = line - 2  # 0-indexed previous line
+        while prev_idx >= 0 and not all_lines[prev_idx].strip():
+            prev_idx -= 1
+        if prev_idx >= 0:
+            prev_stripped = all_lines[prev_idx].rstrip()
+            if prev_stripped and not prev_stripped.endswith((";", "{", "}", ":")):
+                prev_line_num = prev_idx + 1  # back to 1-indexed
+                prev_col = len(prev_stripped)
+                return ParseError(
+                    f"missing ';' (found '{token_text}' on next line)",
+                    file_name=file_name,
+                    line=prev_line_num,
+                    column=prev_col,
+                    token=token_text,
+                    source_line=prev_stripped,
+                )
+
     source_line = ""
-    if line >= 1:
-        try:
-            if os.path.isfile(source):
-                with open(source, encoding="utf-8") as f:
-                    lines = f.readlines()
-            else:
-                lines = source.splitlines(keepends=True)
-            if line <= len(lines):
-                source_line = lines[line - 1].rstrip()
-        except OSError:
-            pass
+    if 1 <= line <= len(all_lines):
+        source_line = all_lines[line - 1].rstrip()
 
     return ParseError(
         msg,

--- a/proof_frog/mcp_server.py
+++ b/proof_frog/mcp_server.py
@@ -154,7 +154,7 @@ def parse(path: str) -> dict[str, Any]:
     The output is the stringified AST on success, or error message on failure.
     Useful for checking syntax in any file type before running a proof.
     """
-    output, success = _capture_parse(_safe_resolve(path))
+    output, success, _err_line, _err_col = _capture_parse(_safe_resolve(path))
     return {"output": output, "success": success}
 
 
@@ -166,7 +166,9 @@ def check(path: str) -> dict[str, Any]:
     More thorough than parse — catches type mismatches, undefined names,
     signature mismatches between Left/Right games, etc.
     """
-    output, success = _capture_check_impl(_safe_resolve(path), allowed_root=_directory)
+    output, success, _err_line, _err_col = _capture_check_impl(
+        _safe_resolve(path), allowed_root=_directory
+    )
     return {"output": output, "success": success}
 
 
@@ -182,7 +184,7 @@ def prove(proof_path: str) -> dict[str, Any]:
     Imports in the proof are resolved relative to the server's working directory.
     Use write_file first to save the proof content to disk, then call prove.
     """
-    output, success, hop_results, _has_induction = _capture_prove(
+    output, success, hop_results, _has_induction, _err_line, _err_col = _capture_prove(
         _safe_resolve(proof_path), allowed_root=_directory
     )
     return {"output": output, "success": success, "hop_results": hop_results}

--- a/proof_frog/proof_frog.py
+++ b/proof_frog/proof_frog.py
@@ -26,7 +26,7 @@ def parse(file: str, json_output: bool) -> None:
         # pylint: disable=import-outside-toplevel
         from .web_server import _capture_parse
 
-        output, success = _capture_parse(file)
+        output, success, _err_line, _err_col = _capture_parse(file)
         click.echo(json.dumps({"output": output, "success": success}))
         return
     try:
@@ -49,7 +49,7 @@ def check(file: str, json_output: bool) -> None:
         # pylint: disable=import-outside-toplevel
         from .web_server import _capture_check
 
-        output, success = _capture_check(file)
+        output, success, _err_line, _err_col = _capture_check(file)
         click.echo(json.dumps({"output": output, "success": success}))
         return
     try:
@@ -77,7 +77,9 @@ def prove(file: str, verbose: bool, json_output: bool) -> None:
         # pylint: disable=import-outside-toplevel
         from .web_server import _capture_prove
 
-        output, success, hop_results, _has_induction = _capture_prove(file)
+        output, success, hop_results, _has_induction, _err_line, _err_col = (
+            _capture_prove(file)
+        )
         click.echo(
             json.dumps(
                 {"output": output, "success": success, "hop_results": hop_results}

--- a/proof_frog/web/editor.js
+++ b/proof_frog/web/editor.js
@@ -298,17 +298,38 @@ export async function saveFile(path) {
   }
 }
 
+// ── Error line highlighting ───────────────────────────────────────────────────
+
+function clearErrorHighlights(cm) {
+  cm.eachLine(handle => {
+    cm.removeLineClass(handle, "background", "cm-error-line");
+  });
+}
+
+function highlightErrorLine(cm, line) {
+  // line is 1-indexed from the parser; CodeMirror uses 0-indexed
+  const zeroLine = line - 1;
+  if (zeroLine >= 0 && zeroLine < cm.lineCount()) {
+    cm.addLineClass(zeroLine, "background", "cm-error-line");
+    cm.scrollIntoView({ line: zeroLine, ch: 0 }, 100);
+  }
+}
+
 // ── Parse / Prove ─────────────────────────────────────────────────────────────
 
 export async function runCommand(endpoint, title) {
   if (!state.activeTab) return;
   const content = getTabContent(state.activeTab);
+  const tab = state.tabs.get(state.activeTab);
   setRunning(true);
   outputPane.classList.add("visible");
-  outputTitle.textContent = `Running ${title} on ${state.tabs.get(state.activeTab)?.name}…`;
+  outputTitle.textContent = `Running ${title} on ${tab?.name}…`;
   outputStatus.textContent = "";
   outputStatus.className = "";
   outputPre.textContent = "";
+
+  // Clear previous error highlights
+  if (tab) clearErrorHighlights(tab.cm);
 
   try {
     const data = await apiFetch(endpoint, {
@@ -318,7 +339,6 @@ export async function runCommand(endpoint, title) {
     });
 
     // Update saved state (auto-save happened server-side)
-    const tab = state.tabs.get(state.activeTab);
     if (tab) { tab.savedContent = content; updateTabEl(state.activeTab); }
 
     outputTitle.textContent = title;
@@ -328,6 +348,10 @@ export async function runCommand(endpoint, title) {
     } else {
       outputStatus.textContent = "✗ Failed";
       outputStatus.className = "error";
+      // Highlight error line in the editor if available
+      if (tab && data.error_line) {
+        highlightErrorLine(tab.cm, data.error_line);
+      }
     }
     outputPre.textContent = data.output || "(no output)";
     if (endpoint === "/api/prove" && Array.isArray(data.hop_results)) {

--- a/proof_frog/web/style.css
+++ b/proof_frog/web/style.css
@@ -254,6 +254,9 @@ select.wizard-input { cursor: pointer; }
 .editor-wrap .CodeMirror { height: 100%; font-size: 13px; font-family: 'Menlo','Monaco','Consolas',monospace; }
 .editor-wrap .CodeMirror-scroll { height: 100%; }
 
+/* Error line highlight */
+.cm-error-line { background: rgba(244, 135, 113, 0.15) !important; }
+
 /* ── Output pane ── */
 #output-pane {
   background: var(--bg2); border-top: 1px solid var(--border);

--- a/proof_frog/web_server.py
+++ b/proof_frog/web_server.py
@@ -47,22 +47,30 @@ def _safe_path(base: str, rel: str) -> Path | None:
         return None
 
 
-def _capture_parse(file_path: str) -> tuple[str, bool]:
+def _capture_parse(
+    file_path: str,
+) -> tuple[str, bool, int | None, int | None]:
     buf = io.StringIO()
     try:
         with redirect_stdout(buf), redirect_stderr(buf):
             root = frog_parser.parse_file(file_path)
             print(root)
-        return _strip_ansi(buf.getvalue()), True
+        return _strip_ansi(buf.getvalue()), True, None, None
     except ValueError as e:
-        return _strip_ansi(buf.getvalue()) + f"\nError: {e}", False
-    except (frog_parser.ParseError, FileNotFoundError) as e:
-        return _strip_ansi(buf.getvalue()) + f"\n{e}", False
+        return _strip_ansi(buf.getvalue()) + f"\nError: {e}", False, None, None
+    except frog_parser.ParseError as e:
+        line = e.line if e.line >= 0 else None
+        col = e.column if e.column >= 0 else None
+        return _strip_ansi(buf.getvalue()) + f"\n{e}", False, line, col
+    except FileNotFoundError as e:
+        return _strip_ansi(buf.getvalue()) + f"\n{e}", False, None, None
     except Exception as e:  # pylint: disable=broad-exception-caught
-        return _strip_ansi(buf.getvalue()) + f"\nError: {e}", False
+        return _strip_ansi(buf.getvalue()) + f"\nError: {e}", False, None, None
 
 
-def _capture_check(file_path: str, allowed_root: str | None = None) -> tuple[str, bool]:
+def _capture_check(
+    file_path: str, allowed_root: str | None = None
+) -> tuple[str, bool, int | None, int | None]:
     buf = io.StringIO()
     try:
         root = frog_parser.parse_file(file_path)
@@ -70,14 +78,18 @@ def _capture_check(file_path: str, allowed_root: str | None = None) -> tuple[str
             semantic_analysis.check_well_formed(
                 root, file_path, allowed_root=allowed_root
             )
-        return f"{file_path} is well-formed.", True
-    except (frog_parser.ParseError, FileNotFoundError) as e:
-        return str(e), False
+        return f"{file_path} is well-formed.", True, None, None
+    except frog_parser.ParseError as e:
+        line = e.line if e.line >= 0 else None
+        col = e.column if e.column >= 0 else None
+        return str(e), False, line, col
+    except FileNotFoundError as e:
+        return str(e), False, None, None
     except semantic_analysis.FailedTypeCheck:
         msg = _strip_ansi(buf.getvalue()) or "Type check failed."
-        return msg, False
+        return msg, False, None, None
     except Exception as e:  # pylint: disable=broad-exception-caught
-        return f"Error: {e}", False
+        return f"Error: {e}", False, None, None
 
 
 def _capture_describe(file_path: str) -> tuple[str, bool]:
@@ -288,7 +300,7 @@ def _capture_inline(
 
 def _capture_prove(
     file_path: str, allowed_root: str | None = None
-) -> tuple[str, bool, list[dict[str, object]], bool]:
+) -> tuple[str, bool, list[dict[str, object]], bool, int | None, int | None]:
     buf = io.StringIO()
     engine = proof_engine.ProofEngine(False)
     proof_succeeded = False
@@ -329,11 +341,43 @@ def _capture_prove(
             for r in engine.hop_results
             if r.depth == 0 and r.kind != "induction_rollover"
         ]
-        return _strip_ansi(buf.getvalue()), proof_succeeded, hop_results, has_induction
-    except (frog_parser.ParseError, FileNotFoundError) as e:
-        return _strip_ansi(buf.getvalue()) + f"\n{e}", False, [], False
+        return (
+            _strip_ansi(buf.getvalue()),
+            proof_succeeded,
+            hop_results,
+            has_induction,
+            None,
+            None,
+        )
+    except frog_parser.ParseError as e:
+        line = e.line if e.line >= 0 else None
+        col = e.column if e.column >= 0 else None
+        return (
+            _strip_ansi(buf.getvalue()) + f"\n{e}",
+            False,
+            [],
+            False,
+            line,
+            col,
+        )
+    except FileNotFoundError as e:
+        return (
+            _strip_ansi(buf.getvalue()) + f"\n{e}",
+            False,
+            [],
+            False,
+            None,
+            None,
+        )
     except Exception as e:  # pylint: disable=broad-exception-caught
-        return _strip_ansi(buf.getvalue()) + f"\nError: {e}", False, [], False
+        return (
+            _strip_ansi(buf.getvalue()) + f"\nError: {e}",
+            False,
+            [],
+            False,
+            None,
+            None,
+        )
 
 
 def _build_tree(path: Path, base: Path) -> dict[str, object]:
@@ -434,8 +478,13 @@ def create_app(directory: str) -> Flask:
         if abs_path is None:
             return jsonify({"error": "Invalid path"}), 403
         abs_path.write_text(content, encoding="utf-8")
-        output, success = _capture_parse(str(abs_path))
-        return jsonify({"output": output, "success": success})
+        output, success, error_line, error_column = _capture_parse(str(abs_path))
+        resp: dict[str, object] = {"output": output, "success": success}
+        if error_line is not None:
+            resp["error_line"] = error_line
+        if error_column is not None:
+            resp["error_column"] = error_column
+        return jsonify(resp)
 
     @app.route("/api/prove", methods=["POST"])
     def run_prove() -> Any:
@@ -448,17 +497,20 @@ def create_app(directory: str) -> Flask:
         if abs_path is None:
             return jsonify({"error": "Invalid path"}), 403
         abs_path.write_text(content, encoding="utf-8")
-        output, success, hop_results, has_induction = _capture_prove(
-            str(abs_path), allowed_root=directory
+        output, success, hop_results, has_induction, error_line, error_column = (
+            _capture_prove(str(abs_path), allowed_root=directory)
         )
-        return jsonify(
-            {
-                "output": output,
-                "success": success,
-                "hop_results": hop_results,
-                "has_induction": has_induction,
-            }
-        )
+        prove_resp: dict[str, object] = {
+            "output": output,
+            "success": success,
+            "hop_results": hop_results,
+            "has_induction": has_induction,
+        }
+        if error_line is not None:
+            prove_resp["error_line"] = error_line
+        if error_column is not None:
+            prove_resp["error_column"] = error_column
+        return jsonify(prove_resp)
 
     @app.route("/api/inline", methods=["POST"])
     def run_inline() -> Any:

--- a/tests/test_parse_errors.py
+++ b/tests/test_parse_errors.py
@@ -1,0 +1,107 @@
+"""Tests for parse error reporting, especially the missing-semicolon heuristic."""
+
+from pathlib import Path
+
+import pytest
+
+from proof_frog.frog_parser import ParseError, parse_primitive_file
+
+
+def _expect_error(tmp_path: Path, source: str) -> ParseError:
+    prim_file = tmp_path / "Test.primitive"
+    prim_file.write_text(source, encoding="utf-8")
+    with pytest.raises(ParseError) as exc_info:
+        parse_primitive_file(str(prim_file))
+    return exc_info.value
+
+
+class TestMissingSemicolonHeuristic:
+    """When a semicolon is missing, the error should point to the previous line."""
+
+    def test_missing_semicolon_between_fields(self, tmp_path: Path) -> None:
+        source = (
+            "Primitive Foo(Int lambda) {\n"
+            "    Int lambda = lambda\n"  # missing semicolon
+            "    BitString<lambda> bar(BitString<lambda> x);\n"
+            "}\n"
+        )
+        err = _expect_error(tmp_path, source)
+        assert "missing ';'" in str(err)
+        assert err.line == 2
+        assert "Int lambda = lambda" in err.source_line
+
+    def test_missing_semicolon_on_function_decl(self, tmp_path: Path) -> None:
+        source = (
+            "Primitive Foo(Int lambda) {\n"
+            "    Int lambda = lambda;\n"
+            "    BitString<lambda> bar(BitString<lambda> x)\n"  # missing semicolon
+            "    BitString<lambda> baz(BitString<lambda> y);\n"
+            "}\n"
+        )
+        err = _expect_error(tmp_path, source)
+        assert "missing ';'" in str(err)
+        assert err.line == 3
+
+    def test_missing_semicolon_with_blank_line(self, tmp_path: Path) -> None:
+        source = (
+            "Primitive Foo(Int lambda) {\n"
+            "    Int lambda = lambda\n"  # missing semicolon
+            "\n"
+            "    BitString<lambda> bar(BitString<lambda> x);\n"
+            "}\n"
+        )
+        err = _expect_error(tmp_path, source)
+        assert "missing ';'" in str(err)
+        assert err.line == 2
+
+    def test_column_points_to_end_of_line(self, tmp_path: Path) -> None:
+        source = (
+            "Primitive Foo(Int lambda) {\n"
+            "    Int lambda = lambda\n"  # missing semicolon
+            "    BitString<lambda> bar(BitString<lambda> x);\n"
+            "}\n"
+        )
+        err = _expect_error(tmp_path, source)
+        assert err.column == len("    Int lambda = lambda")
+
+    def test_error_message_mentions_next_token(self, tmp_path: Path) -> None:
+        source = (
+            "Primitive Foo(Int lambda) {\n"
+            "    Int lambda = lambda\n"  # missing semicolon
+            "    BitString<lambda> bar(BitString<lambda> x);\n"
+            "}\n"
+        )
+        err = _expect_error(tmp_path, source)
+        assert "on next line" in str(err)
+
+
+class TestNormalParseErrors:
+    """Standard parse errors should still report the offending token directly."""
+
+    def test_unexpected_token_after_semicolon(self, tmp_path: Path) -> None:
+        """A line ending with ';' should never trigger the missing-';' heuristic."""
+        source = (
+            "Primitive Foo(Int lambda) {\n"
+            "    Int lambda = lambda;\n"
+            "    BitString<lambda> bar(BitString<lambda> +);\n"
+            "}\n"
+        )
+        err = _expect_error(tmp_path, source)
+        assert "missing ';'" not in str(err)
+
+    def test_error_has_source_line(self, tmp_path: Path) -> None:
+        source = (
+            "Primitive Foo(Int lambda) {\n"
+            "    Int lambda = lambda;\n"
+            "    BitString<lambda> bar(BitString<lambda> +);\n"
+            "}\n"
+        )
+        err = _expect_error(tmp_path, source)
+        assert err.source_line != ""
+
+    def test_error_on_first_line_no_heuristic(self, tmp_path: Path) -> None:
+        """Errors on line 1 should not trigger the heuristic (no previous line)."""
+        source = "notakeyword {\n}\n"
+        err = _expect_error(tmp_path, source)
+        assert "missing ';'" not in str(err)
+        assert err.line == 1


### PR DESCRIPTION
Return structured error location (line/column) from parse and prove API endpoints so the web UI can highlight the offending line in the editor and scroll to it. Add a heuristic in the parser that detects when the real issue is a missing semicolon on the previous line, reporting a clearer error message pointing to the correct location.