### PR TITLE
Add "New File" button and dialog to web UI

### DIFF
--- a/proof_frog/web/app.js
+++ b/proof_frog/web/app.js
@@ -7,6 +7,7 @@ import { saveFile, runCommand, updateToolbar } from './editor.js';
 import { loadFileTree, collapseAll, expandAll } from './file-tree.js';
 import { updateWizardPanel, closeWizardModal, createGameFromWizard } from './wizard.js';
 import { updateGameHopsPanel } from './game-hops.js';
+import { openNewFileModal, closeNewFileModal, createNewFile } from './new-file.js';
 import './resize.js';
 
 // ── Button handlers ───────────────────────────────────────────────────────────
@@ -31,6 +32,18 @@ document.querySelectorAll("#wizard-modal-body input.wizard-input").forEach(inp =
   inp.addEventListener("keydown", e => { if (e.key === "Enter") createGameFromWizard(); });
 });
 
+// ── New-file modal ───────────────────────────────────────────────────────
+document.getElementById("btn-new-file").addEventListener("click", openNewFileModal);
+document.getElementById("newfile-modal-close").addEventListener("click", closeNewFileModal);
+document.getElementById("newfile-modal-cancel").addEventListener("click", closeNewFileModal);
+document.getElementById("newfile-modal-create").addEventListener("click", createNewFile);
+document.getElementById("newfile-modal").addEventListener("click", e => {
+  if (e.target === document.getElementById("newfile-modal")) closeNewFileModal();
+});
+document.querySelectorAll("#newfile-modal-body input.wizard-input, #newfile-modal-body select.wizard-input").forEach(inp => {
+  inp.addEventListener("keydown", e => { if (e.key === "Enter") createNewFile(); });
+});
+
 // ── Induction warning modal ──────────────────────────────────────────────
 function closeInductionModal() {
   document.getElementById("induction-modal").classList.remove("visible");
@@ -50,6 +63,8 @@ document.addEventListener("keydown", e => {
 
 document.addEventListener("keydown", e => {
   if (e.key === "Escape") {
+    const newfile = document.getElementById("newfile-modal");
+    if (newfile.classList.contains("visible")) closeNewFileModal();
     const wizard = document.getElementById("wizard-modal");
     if (wizard.classList.contains("visible")) closeWizardModal();
     const induction = document.getElementById("induction-modal");

--- a/proof_frog/web/index.html
+++ b/proof_frog/web/index.html
@@ -19,6 +19,7 @@
 <div id="app">
   <div id="toolbar">
     <span class="logo"><img src="/prooffrog.png" alt="ProofFrog">ProofFrog</span>
+    <button id="btn-new-file" title="New File">New File</button>
     <button id="btn-save" title="Save (Ctrl+S)" disabled>Save</button>
     <button id="btn-parse" class="primary" title="Parse current file" disabled>Parse</button>
     <button id="btn-prove" class="primary" title="Run proof" disabled style="display:none">Run Proof</button>
@@ -107,6 +108,40 @@
     </div>
     <div id="induction-modal-footer">
       <button id="induction-modal-ok" class="primary">OK</button>
+    </div>
+  </div>
+</div>
+
+<div id="newfile-modal" role="dialog" aria-modal="true" aria-labelledby="newfile-modal-title">
+  <div id="newfile-modal-panel">
+    <div id="newfile-modal-header">
+      <span id="newfile-modal-title">New File</span>
+      <button id="newfile-modal-close" title="Close">&times;</button>
+    </div>
+    <div id="newfile-modal-body">
+      <div>
+        <label class="wizard-label" for="newfile-folder">Folder</label>
+        <select class="wizard-input" id="newfile-folder"></select>
+      </div>
+      <div>
+        <label class="wizard-label" for="newfile-name">File name (without extension)</label>
+        <input class="wizard-input" id="newfile-name" type="text" placeholder="e.g. MyScheme" autocomplete="off">
+      </div>
+      <div>
+        <label class="wizard-label" for="newfile-type">File type</label>
+        <select class="wizard-input" id="newfile-type">
+          <option value=".primitive">.primitive</option>
+          <option value=".scheme">.scheme</option>
+          <option value=".game">.game</option>
+          <option value=".proof">.proof</option>
+          <option value=".md">.md</option>
+        </select>
+      </div>
+      <div id="newfile-error" style="color: var(--error); font-size: 12px; display: none;"></div>
+    </div>
+    <div id="newfile-modal-footer">
+      <button id="newfile-modal-create" class="primary">Create</button>
+      <button id="newfile-modal-cancel">Close</button>
     </div>
   </div>
 </div>

--- a/proof_frog/web/new-file.js
+++ b/proof_frog/web/new-file.js
@@ -1,0 +1,73 @@
+// ── New-file modal logic ──────────────────────────────────────────────────────
+
+import { apiFetch } from './state.js';
+import { loadFileTree } from './file-tree.js';
+import { openFile } from './editor.js';
+
+const modal       = document.getElementById("newfile-modal");
+const folderSel   = document.getElementById("newfile-folder");
+const nameInput   = document.getElementById("newfile-name");
+const typeSel     = document.getElementById("newfile-type");
+const errorDiv    = document.getElementById("newfile-error");
+
+function showError(msg) {
+  errorDiv.textContent = msg;
+  errorDiv.style.display = "block";
+}
+
+function hideError() {
+  errorDiv.style.display = "none";
+  errorDiv.textContent = "";
+}
+
+export async function openNewFileModal() {
+  hideError();
+  nameInput.value = "";
+  try {
+    const dirs = await apiFetch("/api/directories");
+    folderSel.replaceChildren();
+    for (const d of dirs) {
+      const opt = document.createElement("option");
+      opt.value = d;
+      opt.textContent = d === "" ? "(root)" : d;
+      folderSel.appendChild(opt);
+    }
+  } catch (e) {
+    folderSel.replaceChildren();
+    const opt = document.createElement("option");
+    opt.value = "";
+    opt.textContent = "(root)";
+    folderSel.appendChild(opt);
+  }
+  modal.classList.add("visible");
+  nameInput.focus();
+}
+
+export function closeNewFileModal() {
+  modal.classList.remove("visible");
+}
+
+export async function createNewFile() {
+  hideError();
+  const name = nameInput.value.trim();
+  if (!name) { showError("File name is required."); return; }
+  if (/[\/\\:*?"<>|]/.test(name)) { showError("File name contains invalid characters."); return; }
+
+  const folder = folderSel.value;
+  const ext = typeSel.value;
+  const filename = name + ext;
+  const relPath = folder ? folder + "/" + filename : filename;
+
+  try {
+    await apiFetch("/api/file", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: relPath }),
+    });
+    closeNewFileModal();
+    await loadFileTree();
+    openFile(relPath, filename);
+  } catch (e) {
+    showError(e.message || "Failed to create file.");
+  }
+}

--- a/proof_frog/web/style.css
+++ b/proof_frog/web/style.css
@@ -223,6 +223,43 @@ select.wizard-input { cursor: pointer; }
 #induction-modal-footer button.primary { border-color: var(--accent2); color: var(--accent2); }
 #induction-modal-footer button.primary:hover { background: rgba(86,156,214,0.12); }
 
+/* ── New-file modal ── */
+#newfile-modal {
+  position: fixed; inset: 0; z-index: 1000;
+  background: rgba(0,0,0,0.5);
+  display: none; align-items: center; justify-content: center;
+}
+#newfile-modal.visible {
+  display: flex;
+}
+#newfile-modal-panel {
+  background: var(--bg2); border: 1px solid var(--border); border-radius: 5px;
+  width: 380px; max-width: 90vw; display: flex; flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+}
+#newfile-modal-header {
+  display: flex; align-items: center; padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+#newfile-modal-title { flex: 1; font-weight: 600; font-size: 13px; }
+#newfile-modal-close {
+  background: none; border: none; color: var(--text-dim); cursor: pointer;
+  font-size: 18px; padding: 0 2px; line-height: 1;
+}
+#newfile-modal-close:hover { color: var(--text); }
+#newfile-modal-body { padding: 14px; display: flex; flex-direction: column; gap: 8px; }
+#newfile-modal-footer {
+  display: flex; gap: 8px; padding: 10px 14px;
+  border-top: 1px solid var(--border); justify-content: flex-end;
+}
+#newfile-modal-footer button {
+  padding: 5px 14px; border: 1px solid var(--border); border-radius: 3px;
+  background: var(--bg3); color: var(--text); cursor: pointer; font-size: 12px;
+}
+#newfile-modal-footer button:hover { background: var(--bg2); border-color: var(--accent2); }
+#newfile-modal-footer button.primary { border-color: var(--accent2); color: var(--accent2); }
+#newfile-modal-footer button.primary:hover { background: rgba(86,156,214,0.12); }
+
 /* ── Editor area ── */
 #editor-area { flex: 1; display: flex; flex-direction: column; overflow: hidden; min-width: 0; }
 

--- a/proof_frog/web_server.py
+++ b/proof_frog/web_server.py
@@ -456,6 +456,34 @@ def create_app(directory: str) -> Flask:
         except FileNotFoundError:
             return jsonify({"error": "File not found"}), 404
 
+    @app.route("/api/file", methods=["POST"])
+    def create_file() -> Any:
+        data = request.get_json()
+        if not data:
+            return jsonify({"error": "No data"}), 400
+        rel_path = data.get("path", "")
+        abs_path = _safe_path(directory, rel_path)
+        if abs_path is None:
+            return jsonify({"error": "Invalid path"}), 403
+        if abs_path.exists():
+            return jsonify({"error": "File already exists"}), 409
+        abs_path.parent.mkdir(parents=True, exist_ok=True)
+        abs_path.write_text("", encoding="utf-8")
+        return jsonify({"success": True})
+
+    @app.route("/api/directories")
+    def list_directories() -> Any:
+        dirs: list[str] = [""]
+        base = Path(directory)
+        for dirpath, dirnames, _ in os.walk(base):
+            dirnames[:] = [d for d in dirnames if not d.startswith(".")]
+            dirnames.sort(key=str.lower)
+            p = Path(dirpath)
+            if p != base:
+                dirs.append(str(p.relative_to(base)))
+        dirs.sort(key=str.lower)
+        return jsonify(dirs)
+
     @app.route("/api/file", methods=["PUT"])
     def save_file() -> Any:
         rel_path = request.args.get("path", "")


### PR DESCRIPTION
Adds a toolbar button that opens a modal for creating new files. The dialog lets users choose a folder, file name, and type (.primitive/.scheme/.game/.proof/.md). Backend adds POST /api/file and GET /api/directories endpoints.