### PR TITLE
Fix ExpandTupleTransformer crash on nested product types

### DIFF
--- a/proof_frog/frog_ast.py
+++ b/proof_frog/frog_ast.py
@@ -843,3 +843,21 @@ def expand_tuple_type(the_type: BinaryOperation) -> list[Type]:
     assert isinstance(expanded_type, Type)
     unfolded_types.append(expanded_type)
     return unfolded_types
+
+
+def split_tuple_type_top(the_type: BinaryOperation) -> list[Type]:
+    """Split a product type at the top level only (A * B) -> [A, B].
+
+    Unlike expand_tuple_type which fully flattens (A * B) * C -> [A, B, C],
+    this only splits the outermost product: (A * B) * C -> [A * B, C].
+    This is needed when the corresponding tuple value has only 2 elements
+    (because the nested product type is an opaque/alias type at value level).
+    """
+    assert the_type.operator == BinaryOperators.MULTIPLY
+    left_expr = the_type.left_expression
+    right_expr = the_type.right_expression
+    if not isinstance(left_expr, Type):
+        raise ValueError("Tuple type has non-type components")
+    if not isinstance(right_expr, Type):
+        raise ValueError("Tuple type has non-type components")
+    return [left_expr, right_expr]

--- a/proof_frog/visitors.py
+++ b/proof_frog/visitors.py
@@ -1313,9 +1313,7 @@ class ExpandTupleTransformer(Transformer):
                 # If the value has fewer elements than the fully-flattened type,
                 # only split at the top level to match the value's arity.
                 if len(statement.value.values) < len(unfolded_types):
-                    unfolded_types = frog_ast.split_tuple_type_top(
-                        statement.the_type
-                    )
+                    unfolded_types = frog_ast.split_tuple_type_top(statement.the_type)
                 for index, the_type in enumerate(unfolded_types):
                     new_statements.append(
                         frog_ast.Assignment(

--- a/proof_frog/visitors.py
+++ b/proof_frog/visitors.py
@@ -1237,6 +1237,14 @@ class ExpandTupleTransformer(Transformer):
             if self._is_transformable_tuple(field.type, field.name, game):
                 assert isinstance(field.type, frog_ast.BinaryOperation)
                 unfolded_types = frog_ast.expand_tuple_type(field.type)
+                # If the value has fewer elements than the fully-flattened type,
+                # only split at the top level to match the value's arity.
+                if (
+                    field.value
+                    and isinstance(field.value, frog_ast.Tuple)
+                    and len(field.value.values) < len(unfolded_types)
+                ):
+                    unfolded_types = frog_ast.split_tuple_type_top(field.type)
                 for index, the_type in enumerate(unfolded_types):
                     expression = None
                     if field.value:
@@ -1302,6 +1310,12 @@ class ExpandTupleTransformer(Transformer):
                 assert isinstance(statement.the_type, frog_ast.BinaryOperation)
                 unfolded_types = frog_ast.expand_tuple_type(statement.the_type)
                 assert isinstance(statement.value, frog_ast.Tuple)
+                # If the value has fewer elements than the fully-flattened type,
+                # only split at the top level to match the value's arity.
+                if len(statement.value.values) < len(unfolded_types):
+                    unfolded_types = frog_ast.split_tuple_type_top(
+                        statement.the_type
+                    )
                 for index, the_type in enumerate(unfolded_types):
                     new_statements.append(
                         frog_ast.Assignment(

--- a/proof_frog/visitors.py
+++ b/proof_frog/visitors.py
@@ -1237,12 +1237,19 @@ class ExpandTupleTransformer(Transformer):
             if self._is_transformable_tuple(field.type, field.name, game):
                 assert isinstance(field.type, frog_ast.BinaryOperation)
                 unfolded_types = frog_ast.expand_tuple_type(field.type)
-                # If the value has fewer elements than the fully-flattened type,
-                # only split at the top level to match the value's arity.
+                # If the value has fewer elements than the fully-flattened
+                # type, and the right side of the product is itself a nested
+                # product (which is what expand_tuple_type over-flattened),
+                # fall back to a top-level-only split.
                 if (
                     field.value
                     and isinstance(field.value, frog_ast.Tuple)
                     and len(field.value.values) < len(unfolded_types)
+                    and isinstance(
+                        field.type.right_expression, frog_ast.BinaryOperation
+                    )
+                    and field.type.right_expression.operator
+                    == frog_ast.BinaryOperators.MULTIPLY
                 ):
                     unfolded_types = frog_ast.split_tuple_type_top(field.type)
                 for index, the_type in enumerate(unfolded_types):
@@ -1310,9 +1317,19 @@ class ExpandTupleTransformer(Transformer):
                 assert isinstance(statement.the_type, frog_ast.BinaryOperation)
                 unfolded_types = frog_ast.expand_tuple_type(statement.the_type)
                 assert isinstance(statement.value, frog_ast.Tuple)
-                # If the value has fewer elements than the fully-flattened type,
-                # only split at the top level to match the value's arity.
-                if len(statement.value.values) < len(unfolded_types):
+                # If the value has fewer elements than the fully-flattened
+                # type, and the right side of the product is itself a nested
+                # product (which is what expand_tuple_type over-flattened),
+                # fall back to a top-level-only split.
+                if (
+                    len(statement.value.values) < len(unfolded_types)
+                    and isinstance(
+                        statement.the_type.right_expression,
+                        frog_ast.BinaryOperation,
+                    )
+                    and statement.the_type.right_expression.operator
+                    == frog_ast.BinaryOperators.MULTIPLY
+                ):
                     unfolded_types = frog_ast.split_tuple_type_top(statement.the_type)
                 for index, the_type in enumerate(unfolded_types):
                     new_statements.append(

--- a/tests/test_expand_tuples.py
+++ b/tests/test_expand_tuples.py
@@ -303,3 +303,169 @@ def test_expand_tuples(
     transformed_ast = visitors.ExpandTupleTransformer().transform(game_ast)
     print("TRANSFORMED: ", transformed_ast)
     assert expected_ast == transformed_ast
+
+
+# ---------------------------------------------------------------------------
+# split_tuple_type_top unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_split_tuple_type_top_simple() -> None:
+    """(Int * Int) split at top level gives [Int, Int]."""
+    product = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.MULTIPLY, frog_ast.IntType(), frog_ast.IntType()
+    )
+    result = frog_ast.split_tuple_type_top(product)
+    assert result == [frog_ast.IntType(), frog_ast.IntType()]
+
+
+def test_split_tuple_type_top_nested() -> None:
+    """(Int * Int) * Int split at top level gives [Int * Int, Int]."""
+    inner = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.MULTIPLY, frog_ast.IntType(), frog_ast.IntType()
+    )
+    outer = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.MULTIPLY, inner, frog_ast.IntType()
+    )
+    result = frog_ast.split_tuple_type_top(outer)
+    assert len(result) == 2
+    assert result[0] == inner
+    assert result[1] == frog_ast.IntType()
+
+
+def test_split_tuple_type_top_right_nested() -> None:
+    """Int * (Int * Int) split at top level gives [Int, Int * Int]."""
+    inner = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.MULTIPLY, frog_ast.IntType(), frog_ast.IntType()
+    )
+    outer = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.MULTIPLY, frog_ast.IntType(), inner
+    )
+    result = frog_ast.split_tuple_type_top(outer)
+    assert len(result) == 2
+    assert result[0] == frog_ast.IntType()
+    assert result[1] == inner
+
+
+# ---------------------------------------------------------------------------
+# ExpandTupleTransformer with nested product types
+# ---------------------------------------------------------------------------
+
+
+def test_nested_product_field_with_initializer() -> None:
+    """Field with nested product type and initializer falls back to top-level split.
+
+    Int * Int * Int is parsed right-associatively as Int * (Int * Int).
+    expand_tuple_type gives [Int, Int, Int] (3 types) but the value [1, 2]
+    has only 2 elements, so the transformer falls back to split_tuple_type_top:
+    [Int, Int * Int].
+    """
+    game = """
+    Game G() {
+        Int * Int * Int myTuple = [1, [2, 3]];
+        Void Initialize() {
+        }
+    }
+    """
+    game_ast = frog_parser.parse_game(game)
+    transformed = visitors.ExpandTupleTransformer().transform(game_ast)
+
+    assert len(transformed.fields) == 2
+    assert transformed.fields[0].name == "myTuple@0"
+    assert transformed.fields[0].type == frog_ast.IntType()
+    assert transformed.fields[0].value == frog_ast.Integer(1)
+
+    int_int = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.MULTIPLY, frog_ast.IntType(), frog_ast.IntType()
+    )
+    assert transformed.fields[1].name == "myTuple@1"
+    assert transformed.fields[1].type == int_int
+    assert transformed.fields[1].value == frog_ast.Tuple(
+        [frog_ast.Integer(2), frog_ast.Integer(3)]
+    )
+
+
+@pytest.mark.parametrize(
+    "game,expected",
+    [
+        # Nested product type local variable: fallback in transform_block.
+        # The value [100, [200, 300]] has 2 elements but the type
+        # Int * Int * Int (= Int * (Int * Int)) flattens to 3 types,
+        # so the transformer falls back to top-level split.
+        (
+            """
+            Game G() {
+                Int f() {
+                    Int * Int * Int tuple = [100, [200, 300]];
+                    return tuple[0];
+                }
+            }
+            """,
+            """
+            Game G() {
+                Int f() {
+                    Int tuple0 = 100;
+                    Int * Int tuple1 = [200, 300];
+                    return tuple0;
+                }
+            }
+            """,
+        ),
+        # Field with nested product type but no initial value — fully expands
+        # (no fallback) since the arity check requires a value to be present.
+        (
+            """
+            Game G() {
+                Int * Int * Int myTuple;
+                Void Initialize() {
+                    myTuple[0] = 1;
+                    myTuple[1] = 2;
+                    myTuple[2] = 3;
+                }
+            }
+            """,
+            """
+            Game G() {
+                Int myTuple0;
+                Int myTuple1;
+                Int myTuple2;
+                Void Initialize() {
+                    myTuple0 = 1;
+                    myTuple1 = 2;
+                    myTuple2 = 3;
+                }
+            }
+            """,
+        ),
+    ],
+)
+def test_expand_nested_product_tuples(
+    game: str,
+    expected: str,
+) -> None:
+    game_ast = frog_parser.parse_game(game)
+    expected_ast = frog_parser.parse_game(expected)
+
+    int_int = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.MULTIPLY, frog_ast.IntType(), frog_ast.IntType()
+    )
+
+    # Build replace map with both Int and Int*Int field types so that
+    # the substitution matches whichever type appears in the expected output.
+    replace_map = frog_ast.ASTMap(identity=False)
+    for i in range(3):
+        for prefix in ["tuple", "myTuple"]:
+            replace_map.set(
+                frog_ast.Variable(f"{prefix}{i}"),
+                frog_ast.Variable(f"{prefix}@{i}"),
+            )
+            for the_type in [frog_ast.IntType(), int_int]:
+                replace_map.set(
+                    frog_ast.Field(the_type, f"{prefix}{i}", None),
+                    frog_ast.Field(the_type, f"{prefix}@{i}", None),
+                )
+
+    expected_ast = visitors.SubstitutionTransformer(replace_map).transform(expected_ast)
+
+    transformed_ast = visitors.ExpandTupleTransformer().transform(game_ast)
+    assert expected_ast == transformed_ast


### PR DESCRIPTION
## What

- Fixes an `IndexError: list index out of range` crash in `ExpandTupleTransformer` when schemes use nested product types
- Adds `split_tuple_type_top()` to `frog_ast.py` for top-level-only product type splitting
- Falls back to top-level splitting when tuple value arity doesn't match the fully-flattened type count

## Why

I'm translating some proofs of IND-CCA of hybrid PQ/T KEM constructions to ProofFrog. The scheme defines composite types using product types:
```
   Scheme UG(KEM K, NominalGroup NG, PRF H, PRG G) extends KEM {
       Set EncapsKey = K.EncapsKey * NG.GroupElem;
       Set Ciphertext = K.Ciphertext * NG.GroupElem;
       Set DecapsKey = BitString<Nseed>;

       EncapsKey * DecapsKey DeriveKeyPair(BitString<Nseed> seed) {
           ...
           EncapsKey ek = [ek_PQ, ek_T];
           return [ek, seed];
       }
   }
   ```

When `KEMCCA(UG)` is instantiated, the return type of `DeriveKeyPair` becomes `(K.EncapsKey * NG.GroupElem) * BitString<Nseed>` — a nested product type. `expand_tuple_type` fully flattens this to `[K.EncapsKey, NG.GroupElem, BitString<Nseed>]` (3 types), but the tuple value `[ek, seed]` only has 2 elements, causing `transform_block` to crash at `statement.value.values[2]`.

To workaround, I tried defining separate wrapper primitives with explicit `Make`/`Get` methods for each composite type, adding boilerplate overhead to both the scheme and proof files, which feels wrong in several ways (these primitives also have no security definitions, etc)

## Fix

 Rather than changing `expand_tuple_type` (which other code may depend on), this adds a new `split_tuple_type_top()` function that only splits the outermost `*` operator: `(A * B) * C -> [A * B, C]`. The transformer falls back to this when there's a mismatch between the number of flattened types and the number of tuple value elements.

This is applied in `visitors.py`:
- `transform_game` (field declarations)
- `transform_block` (local variable assignments)

Tested against all tests and examples linked from the ProofFrog root