### PR TITLE
Add GET /api/file-metadata endpoint with unit tests

### DIFF
--- a/proof_frog/web_server.py
+++ b/proof_frog/web_server.py
@@ -567,6 +567,82 @@ def create_app(directory: str) -> Flask:
             }
         )
 
+    @app.route("/api/file-metadata")
+    def file_metadata() -> Any:
+        rel_path = request.args.get("path", "")
+        abs_path = _safe_path(directory, rel_path)
+        if abs_path is None:
+            return jsonify({"error": "Invalid path"}), 403
+        file_path_str = str(abs_path)
+        try:
+            file_type = _get_file_type(file_path_str)
+        except ValueError:
+            return jsonify({"error": "Unsupported file type"}), 400
+
+        def _params(params: list[frog_ast.Parameter]) -> list[dict[str, str]]:
+            return [{"type": str(p.type), "name": p.name} for p in params]
+
+        def _fields(fields: list[frog_ast.Field]) -> list[dict[str, str]]:
+            return [{"type": str(f.type), "name": f.name} for f in fields]
+
+        try:
+            result: dict[str, object]
+            if file_type == frog_ast.FileType.PRIMITIVE:
+                prim = frog_parser.parse_primitive_file(file_path_str)
+                result = {
+                    "type": "primitive",
+                    "name": prim.name,
+                    "parameters": _params(prim.parameters),
+                    "fields": _fields(prim.fields),
+                    "methods": [str(m) for m in prim.methods],
+                }
+            elif file_type == frog_ast.FileType.SCHEME:
+                scheme = frog_parser.parse_scheme_file(file_path_str)
+                result = {
+                    "type": "scheme",
+                    "name": scheme.name,
+                    "parameters": _params(scheme.parameters),
+                    "primitive_name": scheme.primitive_name,
+                    "fields": _fields(scheme.fields),
+                    "methods": [str(m.signature) for m in scheme.methods],
+                }
+            elif file_type == frog_ast.FileType.GAME:
+                game_file = frog_parser.parse_game_file(file_path_str)
+                result = {
+                    "type": "game",
+                    "export_name": game_file.name,
+                    "sides": [g.name for g in game_file.games],
+                    "games": [
+                        {
+                            "name": g.name,
+                            "parameters": _params(g.parameters),
+                            "fields": _fields(g.fields),
+                            "methods": [str(m.signature) for m in g.methods],
+                        }
+                        for g in game_file.games
+                    ],
+                }
+            elif file_type == frog_ast.FileType.PROOF:
+                proof_file = frog_parser.parse_proof_file(file_path_str)
+                result = {
+                    "type": "proof",
+                    "lets": [str(let) for let in proof_file.lets],
+                    "assumptions": [str(a) for a in proof_file.assumptions],
+                    "theorem": str(proof_file.theorem),
+                    "steps": [str(s) for s in proof_file.steps],
+                }
+            else:
+                return jsonify({"error": "Unsupported file type"}), 400
+            return jsonify(result)
+        except (
+            frog_parser.ParseError,
+            FileNotFoundError,
+            semantic_analysis.FailedTypeCheck,
+        ) as e:
+            return jsonify({"error": str(e)}), 400
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            return jsonify({"error": f"Error: {e}"}), 400
+
     return app
 
 

--- a/tests/test_file_metadata.py
+++ b/tests/test_file_metadata.py
@@ -1,0 +1,189 @@
+"""Tests for the GET /api/file-metadata endpoint."""
+
+import os
+
+import pytest
+
+from proof_frog.web_server import create_app
+
+
+@pytest.fixture()
+def client():
+    """Flask test client rooted at the examples directory."""
+    examples_dir = os.path.join(os.path.dirname(__file__), "..", "examples")
+    app = create_app(os.path.abspath(examples_dir))
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+class TestPrimitiveMetadata:
+    def test_basic_fields(self, client):
+        resp = client.get("/api/file-metadata?path=Primitives/PRG.primitive")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["type"] == "primitive"
+        assert data["name"] == "PRG"
+
+    def test_parameters(self, client):
+        resp = client.get("/api/file-metadata?path=Primitives/PRG.primitive")
+        data = resp.get_json()
+        names = [p["name"] for p in data["parameters"]]
+        assert "lambda" in names
+        assert "stretch" in names
+        for p in data["parameters"]:
+            assert "type" in p
+            assert "name" in p
+
+    def test_fields(self, client):
+        resp = client.get("/api/file-metadata?path=Primitives/PRG.primitive")
+        data = resp.get_json()
+        field_names = [f["name"] for f in data["fields"]]
+        assert "lambda" in field_names
+        assert "stretch" in field_names
+
+    def test_methods(self, client):
+        resp = client.get("/api/file-metadata?path=Primitives/PRG.primitive")
+        data = resp.get_json()
+        assert isinstance(data["methods"], list)
+        assert len(data["methods"]) >= 1
+        assert "evaluate" in data["methods"][0]
+
+
+class TestSchemeMetadata:
+    def test_basic_fields(self, client):
+        resp = client.get("/api/file-metadata?path=Schemes/SymEnc/OTP.scheme")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["type"] == "scheme"
+        assert data["name"] == "OTP"
+        assert data["primitive_name"] == "SymEnc"
+
+    def test_parameters(self, client):
+        resp = client.get("/api/file-metadata?path=Schemes/SymEnc/OTP.scheme")
+        data = resp.get_json()
+        assert len(data["parameters"]) >= 1
+        names = [p["name"] for p in data["parameters"]]
+        assert "lambda" in names
+
+    def test_fields(self, client):
+        resp = client.get("/api/file-metadata?path=Schemes/SymEnc/OTP.scheme")
+        data = resp.get_json()
+        field_names = [f["name"] for f in data["fields"]]
+        assert "Key" in field_names
+        assert "Message" in field_names
+        assert "Ciphertext" in field_names
+
+    def test_methods(self, client):
+        resp = client.get("/api/file-metadata?path=Schemes/SymEnc/OTP.scheme")
+        data = resp.get_json()
+        method_strs = data["methods"]
+        assert any("KeyGen" in m for m in method_strs)
+        assert any("Enc" in m for m in method_strs)
+        assert any("Dec" in m for m in method_strs)
+
+
+class TestGameMetadata:
+    def test_basic_fields(self, client):
+        resp = client.get("/api/file-metadata?path=Games/PRG/Security.game")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["type"] == "game"
+        assert data["export_name"] == "Security"
+
+    def test_sides(self, client):
+        resp = client.get("/api/file-metadata?path=Games/PRG/Security.game")
+        data = resp.get_json()
+        assert data["sides"] == ["Real", "Random"]
+
+    def test_games_list(self, client):
+        resp = client.get("/api/file-metadata?path=Games/PRG/Security.game")
+        data = resp.get_json()
+        assert len(data["games"]) == 2
+        game_names = [g["name"] for g in data["games"]]
+        assert "Real" in game_names
+        assert "Random" in game_names
+
+    def test_game_structure(self, client):
+        resp = client.get("/api/file-metadata?path=Games/PRG/Security.game")
+        data = resp.get_json()
+        for g in data["games"]:
+            assert "name" in g
+            assert "parameters" in g
+            assert "fields" in g
+            assert "methods" in g
+            assert isinstance(g["parameters"], list)
+            assert isinstance(g["methods"], list)
+
+    def test_game_parameters(self, client):
+        resp = client.get("/api/file-metadata?path=Games/PRG/Security.game")
+        data = resp.get_json()
+        real_game = data["games"][0]
+        assert len(real_game["parameters"]) >= 1
+        assert real_game["parameters"][0]["name"] == "G"
+
+    def test_game_methods(self, client):
+        resp = client.get("/api/file-metadata?path=Games/PRG/Security.game")
+        data = resp.get_json()
+        real_game = data["games"][0]
+        assert any("Query" in m for m in real_game["methods"])
+
+
+class TestProofMetadata:
+    def test_basic_fields(self, client):
+        resp = client.get("/api/file-metadata?path=Book/2/2_13.proof")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["type"] == "proof"
+
+    def test_lets(self, client):
+        resp = client.get("/api/file-metadata?path=Book/2/2_13.proof")
+        data = resp.get_json()
+        assert isinstance(data["lets"], list)
+        assert len(data["lets"]) >= 1
+
+    def test_theorem(self, client):
+        resp = client.get("/api/file-metadata?path=Book/2/2_13.proof")
+        data = resp.get_json()
+        assert isinstance(data["theorem"], str)
+        assert len(data["theorem"]) > 0
+
+    def test_steps(self, client):
+        resp = client.get("/api/file-metadata?path=Book/2/2_13.proof")
+        data = resp.get_json()
+        assert isinstance(data["steps"], list)
+        assert len(data["steps"]) >= 2
+
+    def test_assumptions(self, client):
+        resp = client.get("/api/file-metadata?path=Book/2/2_13.proof")
+        data = resp.get_json()
+        assert isinstance(data["assumptions"], list)
+
+
+class TestErrorCases:
+    def test_nonexistent_file(self, client):
+        resp = client.get("/api/file-metadata?path=nonexistent.primitive")
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "error" in data
+
+    def test_invalid_path_traversal(self, client):
+        resp = client.get("/api/file-metadata?path=../../etc/passwd")
+        assert resp.status_code == 403
+        data = resp.get_json()
+        assert "error" in data
+
+    def test_unsupported_extension(self, client):
+        resp = client.get("/api/file-metadata?path=some_file.txt")
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "error" in data
+
+    def test_missing_path(self, client):
+        resp = client.get("/api/file-metadata")
+        # Empty path resolves to base directory, which has no extension
+        assert resp.status_code == 400
+
+    def test_dotfile_rejected(self, client):
+        resp = client.get("/api/file-metadata?path=.git/config")
+        assert resp.status_code == 403


### PR DESCRIPTION
Add a new web API route that returns structured JSON metadata for .primitive, .scheme, .game, and .proof files by leveraging the existing frog_parser infrastructure. Includes 24 unit tests covering all four file types and error cases (invalid path, nonexistent file, unsupported extension, dotfile rejection).