### PR TITLE
Fix CheckTypeVisitor crash on boolean literals (true/false)

### DIFF
--- a/proof_frog/semantic_analysis.py
+++ b/proof_frog/semantic_analysis.py
@@ -1014,6 +1014,9 @@ class CheckTypeVisitor(VariableTypeVisitor):
     def leave_integer(self, num: frog_ast.Integer) -> None:
         self.ast_type_map.set(num, frog_ast.IntType())
 
+    def leave_boolean(self, bool_const: frog_ast.Boolean) -> None:
+        self.ast_type_map.set(bool_const, frog_ast.BoolType())
+
     def leave_tuple(self, the_tuple: frog_ast.Tuple) -> None:
         types: list[frog_ast.Type] = []
         for expression in the_tuple.values:

--- a/tests/test_check_type_visitor.py
+++ b/tests/test_check_type_visitor.py
@@ -1,0 +1,76 @@
+"""Tests for CheckTypeVisitor handling of literal types."""
+
+import pytest
+
+from proof_frog import frog_parser, semantic_analysis
+
+
+def _check_game(source: str) -> None:
+    """Parse a game string and run CheckTypeVisitor on it."""
+    game = frog_parser.parse_game(source)
+    visitor = semantic_analysis.CheckTypeVisitor({}, "test", {})
+    visitor.visit(game)
+
+
+class TestBooleanLiterals:
+    def test_true_in_assignment(self) -> None:
+        _check_game(
+            """
+            Game G() {
+                Bool flag;
+                Void Initialize() {
+                    flag = true;
+                }
+            }
+            """
+        )
+
+    def test_false_in_assignment(self) -> None:
+        _check_game(
+            """
+            Game G() {
+                Bool flag;
+                Void Initialize() {
+                    flag = false;
+                }
+            }
+            """
+        )
+
+    def test_boolean_in_return(self) -> None:
+        _check_game(
+            """
+            Game G() {
+                Bool Test() {
+                    return true;
+                }
+            }
+            """
+        )
+
+    def test_boolean_in_local_variable(self) -> None:
+        _check_game(
+            """
+            Game G() {
+                Void Initialize() {
+                    Bool x = false;
+                }
+            }
+            """
+        )
+
+
+class TestIntegerLiteralControl:
+    """Control test: integer literals already work."""
+
+    def test_integer_in_assignment(self) -> None:
+        _check_game(
+            """
+            Game G() {
+                Int x;
+                Void Initialize() {
+                    x = 42;
+                }
+            }
+            """
+        )


### PR DESCRIPTION
CheckTypeVisitor was missing a leave_boolean method, so boolean constants never had their type recorded in ast_type_map. This caused a FailedTypeCheck ("Could not determine type of true") when type-checking proof files containing boolean literals in assignments or return statements. Add leave_boolean mirroring the existing leave_integer pattern, with unit tests.