### PR TITLE
Fix Initialize handling in apply_reduction for mismatched signatures

### DIFF
--- a/proof_frog/proof_engine.py
+++ b/proof_frog/proof_engine.py
@@ -712,10 +712,6 @@ class ProofEngine:
         challenger: frog_ast.Game,
         reduction: frog_ast.Reduction,
     ) -> frog_ast.Game:
-        print("Reduction to apply:")
-        print(reduction)
-        print("Challenger:")
-        print(challenger)
         name = "Inlined"
         parameters = challenger.parameters
         new_fields = [
@@ -735,7 +731,7 @@ class ProofEngine:
             reduced_game.methods.insert(0, challenger.get_method("Initialize"))
         elif challenger.has_method("Initialize"):
             # Must combine two methods together
-            # Do so by inserting an arg = challenger.Initialize() at the beginning
+            # Do so by inserting a challenger.Initialize() call at the beginning
             # and then using the inline transformer
             challenger_initialize = challenger.get_method("Initialize")
             reduction_initialize = reduced_game.get_method("Initialize")
@@ -744,11 +740,13 @@ class ProofEngine:
                 [],
             )
             if isinstance(challenger_initialize.signature.return_type, frog_ast.Void):
+                # Case A: Challenger returns Void — call as statement
                 reduction_initialize.block = (
                     frog_ast.Block([call_initialize]) + reduction_initialize.block
                 )
-
-            else:
+            elif reduction_initialize.signature.parameters:
+                # Case B: Challenger returns non-Void and reduction has a
+                # parameter to receive it (existing convention)
                 param = reduction_initialize.signature.parameters[0]
                 reduction_initialize.block = (
                     frog_ast.Block(
@@ -762,10 +760,29 @@ class ProofEngine:
                     )
                     + reduction_initialize.block
                 )
-            reduction_initialize.signature.parameters = []
-            reduction_initialize.signature.return_type = (
-                challenger_initialize.signature.return_type
-            )
+                reduction_initialize.signature.parameters = (
+                    reduction_initialize.signature.parameters[1:]
+                )
+                reduction_initialize.signature.return_type = (
+                    challenger_initialize.signature.return_type
+                )
+            else:
+                # Case C: Challenger returns non-Void but reduction has no
+                # parameters — assign to temp variable and discard
+                reduction_initialize.block = (
+                    frog_ast.Block(
+                        [
+                            frog_ast.Assignment(
+                                copy.deepcopy(
+                                    challenger_initialize.signature.return_type
+                                ),
+                                frog_ast.Variable("_init_result"),
+                                call_initialize,
+                            )
+                        ]
+                    )
+                    + reduction_initialize.block
+                )
             reduction_initialize = visitors.InlineTransformer(
                 {("challenger", "Initialize"): challenger_initialize}
             ).transform(reduction_initialize)

--- a/tests/test_apply_reduction.py
+++ b/tests/test_apply_reduction.py
@@ -1,0 +1,231 @@
+from proof_frog import frog_ast, frog_parser, proof_engine
+
+
+def _make_engine() -> proof_engine.ProofEngine:
+    return proof_engine.ProofEngine(verbose=False)
+
+
+def _get_initialize(game: frog_ast.Game) -> frog_ast.Method:
+    return game.get_method("Initialize")
+
+
+class TestCaseA:
+    """Challenger returns Void, reduction has Initialize."""
+
+    def test_void_challenger_void_reduction(self) -> None:
+        challenger = frog_parser.parse_game("""
+        Game G() {
+            Int x;
+            Void Initialize() {
+                x = 1;
+                return None;
+            }
+            Int Run() {
+                return x;
+            }
+        }
+        """)
+        reduction = frog_parser.parse_reduction("""
+        Reduction R() compose G() against H().Adversary {
+            Int y;
+            Void Initialize() {
+                y = 2;
+                return None;
+            }
+            Int Run() {
+                return y;
+            }
+        }
+        """)
+        result = _make_engine().apply_reduction(challenger, reduction)
+        init = _get_initialize(result)
+        assert isinstance(init.signature.return_type, frog_ast.Void)
+        assert init.signature.parameters == []
+
+
+class TestCaseB:
+    """Challenger returns non-Void, reduction has parameter to receive it."""
+
+    def test_parameter_receives_return_value(self) -> None:
+        challenger = frog_parser.parse_game("""
+        Game G() {
+            Int pk;
+            Int Initialize() {
+                pk = 42;
+                return pk;
+            }
+            Int Test() {
+                return pk;
+            }
+        }
+        """)
+        reduction = frog_parser.parse_reduction("""
+        Reduction R() compose G() against H().Adversary {
+            Int stored_pk;
+            Int Initialize(Int the_pk) {
+                stored_pk = the_pk;
+                return stored_pk;
+            }
+            Int Run() {
+                return stored_pk;
+            }
+        }
+        """)
+        result = _make_engine().apply_reduction(challenger, reduction)
+        init = _get_initialize(result)
+        # Return type should be overwritten to challenger's
+        assert not isinstance(init.signature.return_type, frog_ast.Void)
+        # Parameter should have been consumed
+        assert init.signature.parameters == []
+
+    def test_only_first_parameter_consumed(self) -> None:
+        challenger = frog_parser.parse_game("""
+        Game G() {
+            Int pk;
+            Int Initialize() {
+                pk = 42;
+                return pk;
+            }
+            Int Test() {
+                return pk;
+            }
+        }
+        """)
+        reduction = frog_parser.parse_reduction("""
+        Reduction R() compose G() against H().Adversary {
+            Int stored_pk;
+            Int extra;
+            Int Initialize(Int the_pk, Int bonus) {
+                stored_pk = the_pk;
+                extra = bonus;
+                return stored_pk;
+            }
+            Int Run() {
+                return stored_pk;
+            }
+        }
+        """)
+        result = _make_engine().apply_reduction(challenger, reduction)
+        init = _get_initialize(result)
+        # Only the first parameter should have been consumed
+        assert len(init.signature.parameters) == 1
+        assert init.signature.parameters[0].name == "bonus"
+
+
+class TestCaseC:
+    """Challenger returns non-Void, reduction has no parameters (new case)."""
+
+    def test_no_crash_when_no_parameters(self) -> None:
+        """This case used to crash with IndexError before the fix."""
+        challenger = frog_parser.parse_game("""
+        Game G() {
+            Int pk;
+            Int sk;
+            Int * Int Initialize() {
+                pk = 1;
+                sk = 2;
+                return [pk, sk];
+            }
+            Int Test() {
+                return pk;
+            }
+        }
+        """)
+        reduction = frog_parser.parse_reduction("""
+        Reduction R() compose G() against H().Adversary {
+            Void Initialize() {
+                return None;
+            }
+            Int Run() {
+                return 0;
+            }
+        }
+        """)
+        result = _make_engine().apply_reduction(challenger, reduction)
+        init = _get_initialize(result)
+        # Reduction's return type should be preserved as Void
+        assert isinstance(init.signature.return_type, frog_ast.Void)
+        assert init.signature.parameters == []
+
+    def test_challenger_init_body_inlined(self) -> None:
+        """Challenger's Initialize body should be inlined into the result."""
+        challenger = frog_parser.parse_game("""
+        Game G() {
+            Int pk;
+            Int Initialize() {
+                pk = 42;
+                return pk;
+            }
+            Int Test() {
+                return pk;
+            }
+        }
+        """)
+        reduction = frog_parser.parse_reduction("""
+        Reduction R() compose G() against H().Adversary {
+            Void Initialize() {
+                return None;
+            }
+            Int Run() {
+                return 0;
+            }
+        }
+        """)
+        result = _make_engine().apply_reduction(challenger, reduction)
+        init = _get_initialize(result)
+        # The result should have more statements than just "return None"
+        # because the challenger's Initialize body is inlined
+        assert len(init.block.statements) > 1
+
+
+class TestNoInitialize:
+    """Challenger has Initialize but reduction does not."""
+
+    def test_challenger_initialize_copied(self) -> None:
+        challenger = frog_parser.parse_game("""
+        Game G() {
+            Int x;
+            Void Initialize() {
+                x = 1;
+                return None;
+            }
+            Int Run() {
+                return x;
+            }
+        }
+        """)
+        reduction = frog_parser.parse_reduction("""
+        Reduction R() compose G() against H().Adversary {
+            Int Run() {
+                return 0;
+            }
+        }
+        """)
+        result = _make_engine().apply_reduction(challenger, reduction)
+        assert result.has_method("Initialize")
+
+    def test_nonvoid_challenger_initialize_copied_verbatim(self) -> None:
+        """When reduction has no Initialize, challenger's is used directly."""
+        challenger = frog_parser.parse_game("""
+        Game G() {
+            Int pk;
+            Int Initialize() {
+                pk = 42;
+                return pk;
+            }
+            Int Test() {
+                return pk;
+            }
+        }
+        """)
+        reduction = frog_parser.parse_reduction("""
+        Reduction R() compose G() against H().Adversary {
+            Int Run() {
+                return 0;
+            }
+        }
+        """)
+        result = _make_engine().apply_reduction(challenger, reduction)
+        init = _get_initialize(result)
+        # Should preserve challenger's return type
+        assert not isinstance(init.signature.return_type, frog_ast.Void)


### PR DESCRIPTION
The apply_reduction method had rigid special-case logic for combining the challenger's Initialize method with the reduction's Initialize. When the challenger returned a non-Void type, the code unconditionally assumed the reduction's Initialize had a parameter to receive that return value (line 752: parameters[0]), crashing with an IndexError if the reduction declared Void Initialize() with no parameters. It also unconditionally cleared all parameters and overwrote the return type to match the challenger's, preventing the reduction from presenting a different Initialize signature to the adversary.

This broke compositions where the challenger's Initialize returns a value (e.g., a key pair) but the adversary expects Void Initialize(). The reduction needs to call challenger.Initialize() for its side effects (setting up challenger state) while presenting Void to the adversary.

The fix restructures the elif branch into three cases:

- Case A (unchanged): Challenger returns Void — prepend call as statement.
- Case B (refined): Challenger returns non-Void, reduction has a parameter — existing convention, but now only removes the first parameter instead of clearing all of them.
- Case C (new): Challenger returns non-Void, reduction has no parameters — assigns return value to a temp variable (_init_result) and preserves the reduction's declared return type.

Also removes leftover debug print statements from apply_reduction and adds unit tests covering all three cases plus the no-Initialize fallback path.