### PR TITLE
Improve error messages for proof engine failures

### DIFF
--- a/proof_frog/proof_frog.py
+++ b/proof_frog/proof_frog.py
@@ -119,6 +119,9 @@ def prove(file: str, verbose: bool, json_output: bool) -> None:
         engine.prove(proof_file)
     except proof_engine.FailedProof:
         sys.exit(1)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        click.echo(f"Error during proof verification: {e}", err=True)
+        sys.exit(1)
 
 
 @cli.command()

--- a/proof_frog/visitors.py
+++ b/proof_frog/visitors.py
@@ -657,6 +657,8 @@ class FrogToSympyVisitor(Visitor[Optional[Symbol | int]]):
         self.stack.append(integer.num)
 
     def leave_variable(self, var: frog_ast.Variable) -> None:
+        if var.name not in self.variables:
+            raise KeyError(f"Undefined variable '{var.name}' in expression")
         self.stack.append(self.variables[var.name])
 
 


### PR DESCRIPTION
Catch unexpected exceptions in the CLI prove command and display a clean one-line error instead of a full Python traceback. Also improve the KeyError in FrogToSympyVisitor.leave_variable to include the undefined variable name in the message.