### PR TITLE
Consolidate dependencies into pyproject.toml and remove requirements files

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          pip install -e ".[dev]"
       - name: black
         run: |
           black --check proof_frog

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -23,8 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
+          pip install -e ".[dev]"
       - name: mypy
         run: |
           mypy proof_frog --no-warn-unused-ignores

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -23,8 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
+          pip install -e ".[dev]"
       - name: Analysing the code with pylint
         run: |
           pylint proof_frog

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
+          pip install -e ".[dev]"
       - name: run tests
         run: |
           pytest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,7 @@
 
 ```bash
 python3 -m venv .venv
-.venv/bin/pip install -e .
-.venv/bin/pip install -r requirements-dev.txt
+.venv/bin/pip install -e ".[dev]"
 ```
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ cd ProofFrog
 git submodule update --init
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -e .
-pip install -r requirements-dev.txt
+pip install -e ".[dev]"
 ```
 
 ## Web Interface

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+dev = ["mypy", "pylint", "types-colorama", "pytest", "pytest-xdist", "black"]
 mcp = ["mcp[cli] >= 1.0"]
 
 [project.urls]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,0 @@
-mypy
-pylint
-types-colorama
-pytest
-pytest-xdist
-black

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-antlr4-python3-runtime
-click
-colorama
-flask
-sympy
-z3-solver


### PR DESCRIPTION
Move dev dependencies (mypy, pylint, pytest, etc.) into a [dev] optional-dependency group in pyproject.toml, eliminating the redundant requirements.txt and requirements-dev.txt. Update CI workflows and docs to use `pip install -e ".[dev]"`.