### PR TITLE
Add MCP tools for canonicalization pipeline debugging

### DIFF
--- a/CLAUDE_MCP.md
+++ b/CLAUDE_MCP.md
@@ -62,6 +62,8 @@ Claude will call `prooffrog:list_files` and return the file tree.
 | `prove` | Run proof verification; returns per-hop pass/fail results |
 | `get_step_detail` | Canonical (fully simplified) form of one proof step — key for diagnosing failures |
 | `get_inlined_game` | Canonical form of an arbitrary game step expression evaluated against the proof's `let:` context — use when the step isn't yet in the `games:` list or when stub reductions prevent parsing |
+| `get_canonicalization_trace` | Trace of which transforms fired at each iteration of the fixed-point loop for a step |
+| `get_step_after_transform` | Game AST after applying transforms up to a specific named transform — for inspecting intermediate states |
 
 There is also a **language reference resource** (`prooffrog://language-reference`)
 that Claude can fetch to remind itself of proof DSL syntax without reading through
@@ -118,6 +120,12 @@ When a step fails:
    step to see their canonical forms side-by-side.
 2. Compare the two canonical forms to identify the difference — this usually
    reveals what the engine cannot simplify automatically.
+3. Use `get_canonicalization_trace(proof_path, step_index)` to see which
+   transforms fired at each iteration — helpful for understanding the
+   simplification sequence.
+4. Use `get_step_after_transform(proof_path, step_index, transform_name)` to
+   inspect the game AST after a specific transform — useful when you suspect a
+   particular transform is misbehaving.
 
 ### Validating non-proof files
 

--- a/proof_frog/mcp_server.py
+++ b/proof_frog/mcp_server.py
@@ -34,6 +34,8 @@ from .web_server import (
     _capture_check as _capture_check_impl,
     _capture_prove,
     _capture_inline,
+    _capture_canonicalization_trace,
+    _capture_step_after_transform,
     _build_minimal_proof,
     _build_tree,
 )
@@ -46,7 +48,9 @@ mcp: FastMCP = FastMCP(
         "`describe` to understand their interfaces, `write_file` + `prove` to verify "
         "a proof, `get_step_detail` to diagnose failing proof steps, and "
         "`get_inlined_game` to see the canonical form of a game step without "
-        "needing the full proof to be parseable (useful when writing intermediate games)."
+        "needing the full proof to be parseable (useful when writing intermediate games). "
+        "For debugging failing hops use `get_canonicalization_trace` to see which "
+        "transforms fired and `get_step_after_transform` to inspect intermediate states."
     ),
 )
 
@@ -274,6 +278,52 @@ def get_inlined_game(proof_path: str, step_text: str) -> dict[str, Any]:
         return {"output": output, "canonical": canonical, "success": success}
     except Exception as e:  # pylint: disable=broad-except
         return {"output": f"Error: {e}", "canonical": "", "success": False}
+
+
+# ---------------------------------------------------------------------------
+# Canonicalization debugging tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()  # type: ignore[misc, untyped-decorator]
+def get_canonicalization_trace(proof_path: str, step_index: int) -> Any:
+    """Get a trace of which transforms fired at each fixed-point iteration.
+
+    Use this to understand how the engine simplifies a game step.
+    step_index is 0-based.
+
+    Returns:
+      success          — bool
+      iterations       — list of {iteration: int, transforms_applied: [str]}
+      total_iterations — number of iterations before convergence
+      converged        — whether the fixed-point loop converged
+    """
+    return _capture_canonicalization_trace(
+        _safe_resolve(proof_path), step_index, allowed_root=_directory
+    )
+
+
+@mcp.tool()  # type: ignore[misc, untyped-decorator]
+def get_step_after_transform(
+    proof_path: str, step_index: int, transform_name: str
+) -> Any:
+    """Get the game AST after applying transforms up to a named transform.
+
+    Applies the first iteration of the canonicalization pipeline up to and
+    including the named transform. Useful for inspecting the intermediate
+    state after a specific transformation pass.
+
+    step_index is 0-based.
+
+    Returns:
+      success              — bool
+      output               — game AST as string after the named transform
+      transform_applied    — whether the named transform changed the AST
+      available_transforms — list of valid transform names
+    """
+    return _capture_step_after_transform(
+        _safe_resolve(proof_path), step_index, transform_name, allowed_root=_directory
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/proof_frog/proof_engine.py
+++ b/proof_frog/proof_engine.py
@@ -14,6 +14,8 @@ from . import dependencies
 from .transforms._base import (
     PipelineContext,
     run_pipeline,
+    run_pipeline_until,
+    run_pipeline_with_trace,
     run_standardization,
     _MAX_FIXED_POINT_ITERATIONS,
 )
@@ -608,6 +610,36 @@ class ProofEngine:
         game = run_pipeline(game, CORE_PIPELINE, ctx)
         game = run_standardization(game, STANDARDIZATION_PIPELINE, ctx)
         return game
+
+    def canonicalize_game_with_trace(
+        self, game: frog_ast.Game
+    ) -> tuple[frog_ast.Game, dict[str, object]]:
+        """Same pipeline as canonicalize_game, but records which transforms
+        fired at each iteration of the fixed-point loop."""
+        ctx = self._build_context()
+        game, trace = run_pipeline_with_trace(game, CORE_PIPELINE, ctx)
+        game = run_standardization(game, STANDARDIZATION_PIPELINE, ctx)
+        return game, {
+            "iterations": [
+                {
+                    "iteration": it.iteration,
+                    "transforms_applied": it.transforms_applied,
+                }
+                for it in trace.iterations
+            ],
+            "total_iterations": len(trace.iterations),
+            "converged": trace.converged,
+        }
+
+    def canonicalize_until_transform(
+        self, game: frog_ast.Game, transform_name: str
+    ) -> tuple[frog_ast.Game, bool, list[str]]:
+        """Apply transforms up to and including *transform_name* (first
+        iteration only) and return the resulting game."""
+        ctx = self._build_context()
+        return run_pipeline_until(
+            game, CORE_PIPELINE, STANDARDIZATION_PIPELINE, ctx, transform_name
+        )
 
     def apply_reduction(
         self,

--- a/proof_frog/transforms/_base.py
+++ b/proof_frog/transforms/_base.py
@@ -75,3 +75,89 @@ def run_standardization(
     for pass_ in pipeline:
         game = pass_.apply(game, ctx)
     return game
+
+
+# ---------------------------------------------------------------------------
+# Traced / diagnostic pipeline runners
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class IterationTrace:
+    """Record of one fixed-point iteration."""
+
+    iteration: int
+    transforms_applied: list[str]
+
+
+@dataclass
+class PipelineTrace:
+    """Full trace of a pipeline run."""
+
+    iterations: list[IterationTrace]
+    converged: bool
+
+
+def run_pipeline_with_trace(
+    game: frog_ast.Game,
+    pipeline: list[TransformPass],
+    ctx: PipelineContext,
+    max_iterations: int = _MAX_FIXED_POINT_ITERATIONS,
+) -> tuple[frog_ast.Game, PipelineTrace]:
+    """Run transform passes in a fixed-point loop, recording which fired."""
+    iterations: list[IterationTrace] = []
+    converged = False
+    for iteration in range(max_iterations):
+        transforms_applied: list[str] = []
+        new_game = game
+        for pass_ in pipeline:
+            before = new_game
+            new_game = pass_.apply(new_game, ctx)
+            if new_game != before:
+                transforms_applied.append(pass_.name)
+        if new_game == game:
+            converged = True
+            break
+        iterations.append(
+            IterationTrace(
+                iteration=iteration + 1, transforms_applied=transforms_applied
+            )
+        )
+        game = new_game
+    if not converged:
+        warnings.warn(
+            "Canonicalization did not converge within " f"{max_iterations} iterations",
+            stacklevel=3,
+        )
+    return game, PipelineTrace(iterations=iterations, converged=converged)
+
+
+def run_pipeline_until(
+    game: frog_ast.Game,
+    core_pipeline: list[TransformPass],
+    std_pipeline: list[TransformPass],
+    ctx: PipelineContext,
+    transform_name: str,
+) -> tuple[frog_ast.Game, bool, list[str]]:
+    """Apply transforms up to and including *transform_name* (first iteration).
+
+    Returns ``(game_after, transform_changed_ast, available_names)``.
+    """
+    available_names = [p.name for p in core_pipeline] + [p.name for p in std_pipeline]
+
+    if transform_name not in available_names:
+        return game, False, available_names
+
+    for pass_ in core_pipeline:
+        before = game
+        game = pass_.apply(game, ctx)
+        if pass_.name == transform_name:
+            return game, game != before, available_names
+
+    for pass_ in std_pipeline:
+        before = game
+        game = pass_.apply(game, ctx)
+        if pass_.name == transform_name:
+            return game, game != before, available_names
+
+    return game, False, available_names

--- a/proof_frog/web_server.py
+++ b/proof_frog/web_server.py
@@ -170,6 +170,74 @@ def _build_minimal_proof(proof_text: str, step_text: str) -> str | None:
     return "\n\n".join(parts) + "\n"
 
 
+def _setup_engine_for_proof(
+    file_path: str, allowed_root: str | None = None
+) -> tuple[proof_engine.ProofEngine, frog_ast.ProofFile]:
+    """Parse a proof file, set up an engine with its namespace, and return both.
+
+    Caller is responsible for suppressing stdout/stderr if needed.
+    """
+    proof_file = frog_parser.parse_proof_file(file_path)
+    engine = proof_engine.ProofEngine(False)
+    for imp in proof_file.imports:
+        imp_path = frog_parser.resolve_import_path(
+            imp.filename, file_path, allowed_root=allowed_root
+        )
+        file_type = _get_file_type(imp_path)
+        root: frog_ast.Primitive | frog_ast.Scheme | frog_ast.GameFile
+        match file_type:
+            case frog_ast.FileType.PRIMITIVE:
+                root = frog_parser.parse_primitive_file(imp_path)
+            case frog_ast.FileType.SCHEME:
+                root = frog_parser.parse_scheme_file(imp_path)
+            case frog_ast.FileType.GAME:
+                root = frog_parser.parse_game_file(imp_path)
+            case _:
+                raise TypeError(f"Cannot import {file_type}")
+        name = imp.rename if imp.rename else root.get_export_name()
+        engine.add_definition(name, root)
+    for game in proof_file.helpers:
+        engine.definition_namespace[game.name] = game
+    for let in proof_file.lets:
+        engine.proof_let_types.set(let.name, let.type)
+        if isinstance(let.value, frog_ast.FuncCall) and isinstance(
+            let.value.func, frog_ast.Variable
+        ):
+            definition = copy.deepcopy(engine.definition_namespace[let.value.func.name])
+            if isinstance(definition, (frog_ast.Primitive, frog_ast.Scheme)):
+                engine.proof_namespace[let.name] = proof_engine.instantiate(
+                    definition, let.value.args, engine.proof_namespace
+                )
+            else:
+                raise TypeError("Must instantiate either a Primitive or Scheme")
+        else:
+            engine.proof_namespace[let.name] = copy.deepcopy(let.value)
+    engine.get_method_lookup()
+    return engine, proof_file
+
+
+def _resolve_step_game(
+    engine: proof_engine.ProofEngine,
+    proof_file: frog_ast.ProofFile,
+    step_index: int,
+) -> tuple[frog_ast.Game | None, str]:
+    """Get the inlined game AST for a proof step.  Returns (game, error)."""
+    if step_index < 0 or step_index >= len(proof_file.steps):
+        return None, (
+            f"Step index {step_index} out of range "
+            f"(proof has {len(proof_file.steps)} steps)"
+        )
+    step = proof_file.steps[step_index]
+    if not isinstance(step, frog_ast.Step):
+        return None, "This step is an assumption, not a game step."
+    suppress = io.StringIO()
+    with redirect_stdout(suppress), redirect_stderr(suppress):
+        # pylint: disable=protected-access
+        game = engine._get_game_ast(step.challenger, step.reduction)
+        # pylint: enable=protected-access
+    return game, ""
+
+
 def _capture_inline(
     file_path: str,
     step_index: int,
@@ -178,44 +246,7 @@ def _capture_inline(
     buf = io.StringIO()
     try:
         with redirect_stdout(buf), redirect_stderr(buf):
-            proof_file = frog_parser.parse_proof_file(file_path)
-            engine = proof_engine.ProofEngine(False)
-            for imp in proof_file.imports:
-                imp_path = frog_parser.resolve_import_path(
-                    imp.filename, file_path, allowed_root=allowed_root
-                )
-                file_type = _get_file_type(imp_path)
-                root: frog_ast.Primitive | frog_ast.Scheme | frog_ast.GameFile
-                match file_type:
-                    case frog_ast.FileType.PRIMITIVE:
-                        root = frog_parser.parse_primitive_file(imp_path)
-                    case frog_ast.FileType.SCHEME:
-                        root = frog_parser.parse_scheme_file(imp_path)
-                    case frog_ast.FileType.GAME:
-                        root = frog_parser.parse_game_file(imp_path)
-                    case _:
-                        raise TypeError(f"Cannot import {file_type}")
-                name = imp.rename if imp.rename else root.get_export_name()
-                engine.add_definition(name, root)
-            for game in proof_file.helpers:
-                engine.definition_namespace[game.name] = game
-            for let in proof_file.lets:
-                engine.proof_let_types.set(let.name, let.type)
-                if isinstance(let.value, frog_ast.FuncCall) and isinstance(
-                    let.value.func, frog_ast.Variable
-                ):
-                    definition = copy.deepcopy(
-                        engine.definition_namespace[let.value.func.name]
-                    )
-                    if isinstance(definition, (frog_ast.Primitive, frog_ast.Scheme)):
-                        engine.proof_namespace[let.name] = proof_engine.instantiate(
-                            definition, let.value.args, engine.proof_namespace
-                        )
-                    else:
-                        raise TypeError("Must instantiate either a Primitive or Scheme")
-                else:
-                    engine.proof_namespace[let.name] = copy.deepcopy(let.value)
-            engine.get_method_lookup()
+            engine, proof_file = _setup_engine_for_proof(file_path, allowed_root)
 
         if step_index < 0 or step_index >= len(proof_file.steps):
             return (
@@ -296,6 +327,72 @@ def _capture_inline(
             "",
             "",
         )
+
+
+# ---------------------------------------------------------------------------
+# Canonicalization debugging capture functions
+# ---------------------------------------------------------------------------
+
+
+def _capture_canonicalization_trace(
+    file_path: str, step_index: int, allowed_root: str | None = None
+) -> dict[str, Any]:
+    """Return a trace of which transforms fired per iteration for a step."""
+    buf = io.StringIO()
+    try:
+        with redirect_stdout(buf), redirect_stderr(buf):
+            engine, proof_file = _setup_engine_for_proof(file_path, allowed_root)
+        game, err = _resolve_step_game(engine, proof_file, step_index)
+        if game is None:
+            return {"success": False, "error": err}
+        suppress = io.StringIO()
+        with redirect_stdout(suppress), redirect_stderr(suppress):
+            _canon, trace = engine.canonicalize_game_with_trace(copy.deepcopy(game))
+        trace["success"] = True
+        return trace
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        return {
+            "success": False,
+            "error": _strip_ansi(buf.getvalue()) + f"\nError: {e}",
+        }
+
+
+def _capture_step_after_transform(
+    file_path: str,
+    step_index: int,
+    transform_name: str,
+    allowed_root: str | None = None,
+) -> dict[str, Any]:
+    """Return game AST after applying transforms up to the named one."""
+    buf = io.StringIO()
+    try:
+        with redirect_stdout(buf), redirect_stderr(buf):
+            engine, proof_file = _setup_engine_for_proof(file_path, allowed_root)
+        game, err = _resolve_step_game(engine, proof_file, step_index)
+        if game is None:
+            return {"success": False, "error": err}
+        suppress = io.StringIO()
+        with redirect_stdout(suppress), redirect_stderr(suppress):
+            result_game, changed, available = engine.canonicalize_until_transform(
+                copy.deepcopy(game), transform_name
+            )
+        if transform_name not in available:
+            return {
+                "success": False,
+                "error": f"Unknown transform '{transform_name}'",
+                "available_transforms": available,
+            }
+        return {
+            "success": True,
+            "output": str(result_game),
+            "transform_applied": changed,
+            "available_transforms": available,
+        }
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        return {
+            "success": False,
+            "error": _strip_ansi(buf.getvalue()) + f"\nError: {e}",
+        }
 
 
 def _capture_prove(

--- a/tests/unit/engine/test_canonicalization_trace.py
+++ b/tests/unit/engine/test_canonicalization_trace.py
@@ -1,0 +1,98 @@
+"""Tests for canonicalization trace and step-after-transform tools."""
+
+import copy
+import io
+from contextlib import redirect_stdout, redirect_stderr
+from pathlib import Path
+
+from proof_frog import proof_engine, frog_ast
+from proof_frog.web_server import (
+    _capture_canonicalization_trace,
+    _capture_step_after_transform,
+    _setup_engine_for_proof,
+)
+
+REPO_ROOT = Path(__file__).parent.parent.parent.parent
+EXAMPLES = REPO_ROOT / "examples"
+# A simple proof with multiple steps that all pass
+PROOF_PATH = str(EXAMPLES / "Proofs" / "SymEnc" / "OTUCimpliesOTS.proof")
+
+
+# -- canonicalize_game_with_trace -------------------------------------------
+
+
+def test_trace_matches_canonicalize_game() -> None:
+    """The traced version must produce the same canonical form."""
+    suppress = io.StringIO()
+    with redirect_stdout(suppress), redirect_stderr(suppress):
+        engine, proof_file = _setup_engine_for_proof(
+            PROOF_PATH, allowed_root=str(EXAMPLES)
+        )
+        step = proof_file.steps[0]
+        assert isinstance(step, frog_ast.Step)
+        # pylint: disable=protected-access
+        game = engine._get_game_ast(step.challenger, step.reduction)
+        # pylint: enable=protected-access
+        canon_normal = engine.canonicalize_game(copy.deepcopy(game))
+        canon_traced, trace = engine.canonicalize_game_with_trace(copy.deepcopy(game))
+    assert str(canon_normal) == str(canon_traced)
+    assert trace["converged"] is True
+
+
+def test_trace_has_iterations() -> None:
+    result = _capture_canonicalization_trace(
+        PROOF_PATH, 0, allowed_root=str(EXAMPLES)
+    )
+    assert result["success"] is True
+    assert result["converged"] is True
+    assert result["total_iterations"] >= 1
+    iterations = result["iterations"]
+    assert isinstance(iterations, list)
+    assert len(iterations) >= 1
+    for it in iterations:
+        assert "iteration" in it
+        assert "transforms_applied" in it
+        assert isinstance(it["transforms_applied"], list)
+
+
+def test_trace_invalid_step() -> None:
+    result = _capture_canonicalization_trace(
+        PROOF_PATH, 999, allowed_root=str(EXAMPLES)
+    )
+    assert result["success"] is False
+
+
+# -- get_step_after_transform -----------------------------------------------
+
+
+def test_step_after_valid_transform() -> None:
+    result = _capture_step_after_transform(
+        PROOF_PATH, 0, "Simplify Returns", allowed_root=str(EXAMPLES)
+    )
+    assert result["success"] is True
+    assert isinstance(result["output"], str)
+    assert "transform_applied" in result
+    assert isinstance(result["available_transforms"], list)
+
+
+def test_step_after_invalid_transform() -> None:
+    result = _capture_step_after_transform(
+        PROOF_PATH, 0, "Nonexistent Transform", allowed_root=str(EXAMPLES)
+    )
+    assert result["success"] is False
+    assert "available_transforms" in result
+
+
+def test_step_after_standardization_transform() -> None:
+    result = _capture_step_after_transform(
+        PROOF_PATH, 0, "Variable Standardization", allowed_root=str(EXAMPLES)
+    )
+    assert result["success"] is True
+    assert isinstance(result["output"], str)
+
+
+def test_step_after_transform_invalid_step() -> None:
+    result = _capture_step_after_transform(
+        PROOF_PATH, 999, "Simplify Returns", allowed_root=str(EXAMPLES)
+    )
+    assert result["success"] is False


### PR DESCRIPTION
- get_canonicalization_trace: shows which transforms fired per iteration
- get_step_after_transform: returns game AST after a specific transform

Also extracts _setup_engine_for_proof() helper in web_server.py to deduplicate engine setup across capture functions.