### PR TITLE
Fix instantiation, inlining, and encoding elimination in the proof engine

### DIFF
--- a/proof_frog/semantic_analysis.py
+++ b/proof_frog/semantic_analysis.py
@@ -1027,10 +1027,25 @@ class CheckTypeVisitor(VariableTypeVisitor):
             self.print_error(reduction, "Adversary must be a game file")
             return
 
-        adversary_type = self.instantiate_and_get_type(
-            adversary_definition.games[0],
-            reduction.play_against.args,
+        # Build a combined namespace so that scheme FuncCalls in the adversary
+        # args (e.g. UG(K, NG, H, G) in KEMCCA(UG(K, NG, H, G)).Adversary) can
+        # be expanded to their field types. Scheme/primitive definitions live in
+        # import_namespace but not in instantiation_namespace.
+        combined_ns: frog_ast.Namespace = {
+            **self.instantiation_namespace,
+            **{
+                name: val
+                for name, val in self.import_namespace.items()
+                if isinstance(val, (frog_ast.Scheme, frog_ast.Primitive))
+            },
+        }
+        adversary_type = get_type_from_instantiable(
             reduction.play_against.name,
+            proof_engine.instantiate(
+                adversary_definition.games[0],
+                reduction.play_against.args,
+                combined_ns,
+            ),
             True,
         )
         reduction_type = get_type_from_instantiable(reduction.name, reduction, True)
@@ -1734,9 +1749,20 @@ class CheckTypeVisitor(VariableTypeVisitor):
                     f"{args[index]} is not of type {param.type}",
                 )
 
-        instantiated_scheme = proof_engine.instantiate(
-            scheme, args, self.instantiation_namespace
-        )
+        # Build a combined namespace so that scheme/primitive FuncCall args
+        # (e.g. UG(K, NG, H, G)) can be expanded to their field types during
+        # instantiation. Scheme/primitive definitions live in import_namespace
+        # but not in instantiation_namespace.
+        combined_ns: frog_ast.Namespace = {
+            **self.instantiation_namespace,
+            **{
+                name: val
+                for name, val in self.import_namespace.items()
+                if isinstance(val, (frog_ast.Scheme, frog_ast.Primitive))
+            },
+        }
+
+        instantiated_scheme = proof_engine.instantiate(scheme, args, combined_ns)
 
         # Extract subsets constraints from requires clauses
         subsets_pairs = _extract_subsets_pairs(instantiated_scheme)
@@ -1753,7 +1779,7 @@ class CheckTypeVisitor(VariableTypeVisitor):
             file_name,
             self.file_name_mapping,
             stack,
-            copy.deepcopy(self.instantiation_namespace),
+            copy.deepcopy(combined_ns),
             self.subsets_pairs,
         ).visit(instantiated_scheme)
         return instantiated_scheme

--- a/proof_frog/transforms/pipelines.py
+++ b/proof_frog/transforms/pipelines.py
@@ -25,7 +25,12 @@ from .algebraic import (
     ModIntSimplification,
     ReflexiveComparison,
 )
-from .structural import TopologicalSort, RemoveDuplicateFields, RemoveUnnecessaryFields
+from .structural import (
+    TopologicalSort,
+    RemoveDuplicateFields,
+    RemoveUnnecessaryFields,
+    TrivialEncodingElimination,
+)
 from .control_flow import (
     BranchElimination,
     SimplifyReturn,
@@ -46,6 +51,7 @@ CORE_PIPELINE: list[TransformPass] = [
     MergeUniformSamples(),
     MergeProductSamples(),
     SplitUniformSamples(),
+    TrivialEncodingElimination(),
     RedundantCopy(),
     InlineSingleUseVariable(),
     UniformXorSimplification(),

--- a/proof_frog/transforms/structural.py
+++ b/proof_frog/transforms/structural.py
@@ -7,12 +7,61 @@ expressions or blocks.
 from __future__ import annotations
 
 import copy
+from typing import Optional
 
 from .. import frog_ast
 from .. import visitors
 from .. import dependencies
 from .control_flow import RemoveStatementTransformer
 from ._base import TransformPass, PipelineContext
+
+
+class _TrivialEncodingTransformer(visitors.Transformer):
+    """Replace Prim.EncodeXxx(arg) with arg when Xxx == BitString<n> == return type.
+
+    After instantiation, if a primitive's source Set for an encoding function is
+    itself a BitString of the same size as the encoding target, the function is
+    the identity and can be eliminated.  For example, if K.SharedSecret =
+    BitString<prf_lambda> and K.EncodeSharedSecret returns BitString<prf_lambda>,
+    then K.EncodeSharedSecret(x) simplifies to x.
+    """
+
+    def __init__(self, proof_namespace: frog_ast.Namespace) -> None:
+        self.proof_namespace = proof_namespace
+
+    def transform_func_call(self, func_call: frog_ast.FuncCall) -> frog_ast.ASTNode:
+        # Transform children first.
+        new_func = self.transform(func_call.func)
+        new_args = [self.transform(arg) for arg in func_call.args]
+
+        # Pattern: Prim.EncodeXxx(single_arg)
+        if (
+            isinstance(new_func, frog_ast.FieldAccess)
+            and isinstance(new_func.the_object, frog_ast.Variable)
+            and len(new_args) == 1
+        ):
+            prim_name = new_func.the_object.name
+            method_name = new_func.name
+            prim = self.proof_namespace.get(prim_name)
+            if isinstance(prim, frog_ast.Primitive):
+                method_sig: Optional[frog_ast.MethodSignature] = next(
+                    (m for m in prim.methods if m.name == method_name), None
+                )
+                if (
+                    method_sig is not None
+                    and len(method_sig.parameters) == 1
+                    and isinstance(
+                        method_sig.parameters[0].type, frog_ast.BitStringType
+                    )
+                    and isinstance(method_sig.return_type, frog_ast.BitStringType)
+                    and method_sig.parameters[0].type == method_sig.return_type
+                ):
+                    return new_args[0]
+
+        result = copy.deepcopy(func_call)
+        result.func = new_func
+        result.args = new_args
+        return result
 
 
 def remove_duplicate_fields(game: frog_ast.Game) -> frog_ast.Game:
@@ -64,3 +113,12 @@ class RemoveUnnecessaryFields(TransformPass):
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
         return dependencies.remove_unnecessary_fields(game)
+
+
+class TrivialEncodingElimination(TransformPass):
+    """Remove identity encoding calls: Prim.EncodeXxx(x) -> x when Xxx = BitString<n>."""
+
+    name = "Trivial Encoding Elimination"
+
+    def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
+        return _TrivialEncodingTransformer(ctx.proof_namespace).transform(game)

--- a/proof_frog/visitors.py
+++ b/proof_frog/visitors.py
@@ -298,6 +298,53 @@ class InstantiationTransformer(Transformer):
                             [v for v in result.values if isinstance(v, frog_ast.Type)]
                         )
                     return result
+        # Handle FuncCall.field case, e.g. UG(K, NG, H, G).EncapsKey.
+        # After SubstitutionTransformer replaces a scheme parameter with a FuncCall,
+        # type-position field accesses like K.EncapsKey become
+        # FuncCall("UG", [K, NG, H, G]).EncapsKey. Look up the field in the named
+        # scheme and substitute the scheme's parameters with the FuncCall's args.
+        if (
+            isinstance(field_access.the_object, frog_ast.FuncCall)
+            and isinstance(field_access.the_object.func, frog_ast.Variable)
+            and field_access.the_object.func.name in self.namespace
+        ):
+            func_call = field_access.the_object
+            assert isinstance(func_call.func, frog_ast.Variable)
+            scheme_def = self.namespace[func_call.func.name]
+            if isinstance(scheme_def, (frog_ast.Scheme, frog_ast.Primitive)):
+                the_field = next(
+                    (
+                        field.value
+                        for field in scheme_def.fields
+                        if field.name == field_access.name
+                    ),
+                    None,
+                )
+                if the_field is not None:
+                    result = copy.deepcopy(the_field)
+                    # Substitute scheme parameters with the FuncCall's actual args
+                    param_map = frog_ast.ASTMap[frog_ast.ASTNode](identity=False)
+                    for idx, param in enumerate(scheme_def.parameters):
+                        if idx < len(func_call.args):
+                            param_map.set(
+                                frog_ast.Variable(param.name),
+                                copy.deepcopy(func_call.args[idx]),
+                            )
+                    result = SubstitutionTransformer(param_map).transform(result)
+                    # Further resolve any remaining FieldAccess nodes through the
+                    # current namespace (e.g. Variable("K").EncapsKey -> EncapsKeySpace
+                    # when K is a concrete instantiated scheme in the namespace).
+                    result = InstantiationTransformer(self.namespace).transform(result)
+                    # Convert Tuple of types to ProductType for Set field aliases
+                    if (
+                        isinstance(result, frog_ast.Tuple)
+                        and result.values
+                        and all(isinstance(v, frog_ast.Type) for v in result.values)
+                    ):
+                        return frog_ast.ProductType(
+                            [v for v in result.values if isinstance(v, frog_ast.Type)]
+                        )
+                    return result
         return field_access
 
 
@@ -370,11 +417,18 @@ class InlineTransformer(Transformer):
 
         statements_so_far += list(transformed_method.block.statements[:-1])
 
-        final_statement = transformed_method.block.statements[-1]
-
         statements_after = list(
             block_to_transform.statements[self.statement_index + 1 :]
         )
+
+        if not transformed_method.block.statements:
+            # Empty method body (e.g. a Void Initialize with no statements):
+            # drop the call site entirely and continue with surrounding statements.
+            self.blocks.append(frog_ast.Block(statements_so_far + statements_after))
+            self.finished = True
+            return exp
+
+        final_statement = transformed_method.block.statements[-1]
 
         if isinstance(final_statement, frog_ast.ReturnStatement):
             returned_exp = final_statement.expression

--- a/tests/unit/engine/test_this_inlining.py
+++ b/tests/unit/engine/test_this_inlining.py
@@ -1,4 +1,5 @@
-"""Tests that 'this' references in scheme methods are rewritten for inlining."""
+"""Tests that 'this' references in scheme methods are rewritten for inlining,
+and that InlineTransformer handles edge cases like empty method bodies."""
 
 import copy
 
@@ -93,3 +94,42 @@ def test_this_inlined_via_fixed_point() -> None:
     assert isinstance(assign, frog_ast.Assignment)
     assert isinstance(assign.value, frog_ast.Integer)
     assert assign.value.num == 42
+
+
+def test_inline_empty_void_method_drops_call() -> None:
+    """Inlining a Void method with an empty body should drop the call site.
+
+    Regression test for an IndexError that occurred when inlining methods with
+    no statements (e.g., PRFSec.Random.Initialize() has an empty body).
+    """
+    # Build an empty Void method: Void EmptyInit() {}
+    empty_method = frog_ast.Method(
+        frog_ast.MethodSignature("EmptyInit", frog_ast.Void(), []),
+        frog_ast.Block([]),
+    )
+    lookup = {("S", "EmptyInit"): empty_method}
+
+    # Build a game whose Initialize calls S.EmptyInit() followed by a return.
+    # FuncCall is itself a Statement node in frog_ast.
+    call_stmt = frog_ast.FuncCall(
+        frog_ast.FieldAccess(frog_ast.Variable("S"), "EmptyInit"),
+        [],
+    )
+    ret_stmt = frog_ast.ReturnStatement(frog_ast.Integer(1))
+    game_method = frog_ast.Method(
+        frog_ast.MethodSignature("Initialize", frog_ast.IntType(), []),
+        frog_ast.Block([call_stmt, ret_stmt]),
+    )
+    game = frog_ast.Game(("TestGame", [], [], [game_method], []))
+
+    # Run inlining — should not raise IndexError
+    for _ in range(10):
+        new_game = visitors.InlineTransformer(lookup).transform(copy.deepcopy(game))
+        if new_game == game:
+            break
+        game = new_game
+
+    # The call to EmptyInit should have been dropped; only the return remains
+    init = game.get_method("Initialize")
+    assert len(init.block.statements) == 1
+    assert isinstance(init.block.statements[0], frog_ast.ReturnStatement)

--- a/tests/unit/transforms/test_trivial_encoding_elimination.py
+++ b/tests/unit/transforms/test_trivial_encoding_elimination.py
@@ -1,0 +1,113 @@
+"""Tests for TrivialEncodingElimination transform pass."""
+
+import pytest
+from proof_frog import frog_parser, frog_ast
+from proof_frog.transforms.structural import TrivialEncodingElimination
+from proof_frog.transforms._base import PipelineContext
+
+
+def _make_ctx(primitives: dict[str, frog_ast.Primitive]) -> PipelineContext:
+    return PipelineContext(
+        variables={},
+        proof_let_types={},
+        proof_namespace=dict(primitives),
+        subsets_pairs=[],
+    )
+
+
+def _prim(prim_text: str) -> frog_ast.Primitive:
+    return frog_parser.parse_primitive_file(prim_text)
+
+
+@pytest.mark.parametrize(
+    "game_text,expected_text,prims",
+    [
+        # Identity encoding: K.EncodeSharedSecret(x) -> x when input == output type
+        (
+            """
+            Game Test() {
+                BitString<256> f(BitString<256> x) {
+                    return K.EncodeSharedSecret(x);
+                }
+            }
+            """,
+            """
+            Game Test() {
+                BitString<256> f(BitString<256> x) {
+                    return x;
+                }
+            }
+            """,
+            {
+                "K": "Primitive K() { BitString<256> EncodeSharedSecret(BitString<256> ss); }"
+            },
+        ),
+        # Non-identity encoding: input and output types differ -> no simplification
+        (
+            """
+            Game Test() {
+                BitString<512> f(BitString<256> x) {
+                    return H.hash(x);
+                }
+            }
+            """,
+            """
+            Game Test() {
+                BitString<512> f(BitString<256> x) {
+                    return H.hash(x);
+                }
+            }
+            """,
+            {"H": "Primitive H() { BitString<512> hash(BitString<256> x); }"},
+        ),
+        # Two-argument method: should NOT simplify
+        (
+            """
+            Game Test() {
+                BitString<256> f(BitString<256> x, BitString<256> y) {
+                    return K.Encode(x, y);
+                }
+            }
+            """,
+            """
+            Game Test() {
+                BitString<256> f(BitString<256> x, BitString<256> y) {
+                    return K.Encode(x, y);
+                }
+            }
+            """,
+            {
+                "K": "Primitive K() { BitString<256> Encode(BitString<256> a, BitString<256> b); }"
+            },
+        ),
+        # Unknown primitive name: should NOT simplify (identity-safe no-op)
+        (
+            """
+            Game Test() {
+                BitString<256> f(BitString<256> x) {
+                    return K.Encode(x);
+                }
+            }
+            """,
+            """
+            Game Test() {
+                BitString<256> f(BitString<256> x) {
+                    return K.Encode(x);
+                }
+            }
+            """,
+            {},  # no primitives in namespace
+        ),
+    ],
+)
+def test_trivial_encoding_elimination(
+    game_text: str,
+    expected_text: str,
+    prims: dict[str, str],
+) -> None:
+    game = frog_parser.parse_game(game_text)
+    expected = frog_parser.parse_game(expected_text)
+    ctx = _make_ctx({name: _prim(src) for name, src in prims.items()})
+
+    result = TrivialEncodingElimination().apply(game, ctx)
+    assert result == expected

--- a/tests/unit/visitors/test_instantiation_transformer.py
+++ b/tests/unit/visitors/test_instantiation_transformer.py
@@ -1,0 +1,108 @@
+"""Tests for InstantiationTransformer, especially the FuncCall.field case."""
+
+from proof_frog import frog_ast, visitors
+
+
+def _make_scheme_with_field_alias(
+    scheme_name: str, param_name: str, field_name: str, field_alias_on: str
+) -> frog_ast.Scheme:
+    """Return a scheme with one Set field that aliases a field from a parameter.
+
+    Generates the equivalent of:
+        Scheme <scheme_name>(<param_name>) extends SomePrimitive {
+            Set <field_name> = <param_name>.<field_alias_on>;
+        }
+    """
+    the_field = frog_ast.Field(
+        frog_ast.SetType(),
+        field_name,
+        frog_ast.FieldAccess(frog_ast.Variable(param_name), field_alias_on),
+    )
+    param = frog_ast.Parameter(frog_ast.Variable(param_name), param_name)
+    return frog_ast.Scheme(
+        imports=[],
+        name=scheme_name,
+        parameters=[param],
+        primitive_name="SomePrimitive",
+        fields=[the_field],
+        requirements=[],
+        methods=[],
+    )
+
+
+def _make_primitive_with_bitstring_field(
+    prim_name: str, field_name: str, size: int
+) -> frog_ast.Primitive:
+    """Return a primitive with one Set field that is BitString<size>."""
+    the_field = frog_ast.Field(
+        frog_ast.SetType(),
+        field_name,
+        frog_ast.BitStringType(frog_ast.Integer(size)),
+    )
+    return frog_ast.Primitive(
+        name=prim_name,
+        parameters=[],
+        fields=[the_field],
+        methods=[],
+    )
+
+
+def test_funccall_field_resolves_through_scheme_parameter() -> None:
+    """FuncCall(Variable('UG'), [Variable('K')]).EncapsKey should resolve.
+
+    When the namespace contains:
+      - 'UG' -> Scheme with parameter K_param and field EncapsKey = K_param.EncapsKey
+      - 'K'  -> Primitive with field EncapsKey = BitString<256>
+
+    Then InstantiationTransformer should transform
+      FieldAccess(FuncCall(Variable('UG'), [Variable('K')]), 'EncapsKey')
+    into BitStringType(Integer(256)).
+    """
+    # UG scheme: Scheme UG(K_param) { Set EncapsKey = K_param.EncapsKey; }
+    ug_scheme = _make_scheme_with_field_alias(
+        scheme_name="UG",
+        param_name="K_param",
+        field_name="EncapsKey",
+        field_alias_on="EncapsKey",
+    )
+    # K primitive: Primitive K() { Set EncapsKey = BitString<256>; }
+    k_prim = _make_primitive_with_bitstring_field("K", "EncapsKey", 256)
+
+    namespace: frog_ast.Namespace = {"UG": ug_scheme, "K": k_prim}
+
+    # Build FuncCall(Variable("UG"), [Variable("K")]).EncapsKey
+    func_call = frog_ast.FuncCall(frog_ast.Variable("UG"), [frog_ast.Variable("K")])
+    node = frog_ast.FieldAccess(func_call, "EncapsKey")
+
+    result = visitors.InstantiationTransformer(namespace).transform(node)
+    expected = frog_ast.BitStringType(frog_ast.Integer(256))
+    assert result == expected
+
+
+def test_funccall_field_missing_field_returns_original() -> None:
+    """If the field doesn't exist on the scheme, the node is returned unchanged."""
+    ug_scheme = _make_scheme_with_field_alias("UG", "K_param", "EncapsKey", "EncapsKey")
+    k_prim = _make_primitive_with_bitstring_field("K", "EncapsKey", 256)
+    namespace: frog_ast.Namespace = {"UG": ug_scheme, "K": k_prim}
+
+    func_call = frog_ast.FuncCall(frog_ast.Variable("UG"), [frog_ast.Variable("K")])
+    node = frog_ast.FieldAccess(func_call, "NonExistentField")
+
+    result = visitors.InstantiationTransformer(namespace).transform(node)
+    # Should return unchanged (still a FieldAccess on the FuncCall)
+    assert isinstance(result, frog_ast.FieldAccess)
+    assert result.name == "NonExistentField"
+
+
+def test_funccall_field_unknown_scheme_returns_original() -> None:
+    """If the scheme name is not in the namespace, the node is returned unchanged."""
+    namespace: frog_ast.Namespace = {}  # empty
+
+    func_call = frog_ast.FuncCall(
+        frog_ast.Variable("Unknown"), [frog_ast.Variable("K")]
+    )
+    node = frog_ast.FieldAccess(func_call, "EncapsKey")
+
+    result = visitors.InstantiationTransformer(namespace).transform(node)
+    assert isinstance(result, frog_ast.FieldAccess)
+    assert result.name == "EncapsKey"


### PR DESCRIPTION
visitors.py (InstantiationTransformer): handle FuncCall.field patterns such as Scheme(P1, P2).SomeField so that field accesses on parameterized scheme instantiations resolve correctly via parameter substitution and a second pass.

visitors.py (InlineTransformer): fix IndexError when inlining Void methods whose body is empty (no statements); drop the call site cleanly instead of crashing on statements[-1].

semantic_analysis.py: use a combined namespace (instantiation_namespace + scheme/primitive definitions from import_namespace) when computing adversary types in visit_reduction and _check_instantiation, fixing false "method does not exist in reduction" errors for proofs with parameterized reductions.

transforms/structural.py + pipelines.py: add TrivialEncodingElimination pass that replaces Prim.EncodeXxx(x) with x when the method has identical BitString input and output types (i.e., it is the identity function after instantiation). This is needed for proofs where a primitive's set is already a BitString of the same size as the encoding target.

Add unit tests: TrivialEncodingElimination (4), InlineTransformer empty body (1 regression), InstantiationTransformer FuncCall.field resolution (3).