### PR TITLE
Add live reload to web server via SSE and watchdog

### DIFF
--- a/proof_frog/web/app.js
+++ b/proof_frog/web/app.js
@@ -14,6 +14,7 @@ import {
 } from './wizard.js';
 import { updateGameHopsPanel } from './game-hops.js';
 import { openNewFileModal, closeNewFileModal, createNewFile } from './new-file.js';
+import { connectSSE } from './live-reload.js';
 import './resize.js';
 
 // ── Button handlers ───────────────────────────────────────────────────────────
@@ -78,3 +79,4 @@ updateToolbar();
 loadFileTree();
 updateWizardPanel();
 updateGameHopsPanel();
+connectSSE();

--- a/proof_frog/web/live-reload.js
+++ b/proof_frog/web/live-reload.js
@@ -1,0 +1,121 @@
+// ── Live reload via Server-Sent Events ──────────────────────────────────────
+// Listens for filesystem change events from the server and updates open tabs
+// or the file tree accordingly.
+
+import { state, apiFetch } from './state.js';
+import { loadFileTree } from './file-tree.js';
+
+// ── Notification bar for dirty-tab conflicts ─────────────────────────────────
+
+function showReloadBar(path, name) {
+  // Don't duplicate
+  if (document.querySelector(`.reload-bar[data-path="${CSS.escape(path)}"]`)) return;
+
+  const bar = document.createElement("div");
+  bar.className = "reload-bar";
+  bar.dataset.path = path;
+
+  const msg = document.createElement("span");
+  msg.textContent = `"${name}" changed on disk.`;
+  const btn = document.createElement("button");
+  btn.textContent = "Reload";
+  btn.addEventListener("click", async () => {
+    await reloadTab(path);
+    bar.remove();
+  });
+  const dismiss = document.createElement("button");
+  dismiss.textContent = "Dismiss";
+  dismiss.addEventListener("click", () => bar.remove());
+
+  bar.append(msg, btn, dismiss);
+
+  // Insert at the top of the editor wrap for this tab
+  const tab = state.tabs.get(path);
+  if (tab?.wrap) {
+    tab.wrap.prepend(bar);
+  }
+}
+
+function removeReloadBar(path) {
+  const bar = document.querySelector(`.reload-bar[data-path="${CSS.escape(path)}"]`);
+  if (bar) bar.remove();
+}
+
+// ── Reload a tab's content from disk ─────────────────────────────────────────
+
+async function reloadTab(path) {
+  const tab = state.tabs.get(path);
+  if (!tab) return;
+  try {
+    const data = await apiFetch(`/api/file?path=${encodeURIComponent(path)}`);
+    if (data.error) return;
+    const cursor = tab.cm.getCursor();
+    const scroll = tab.cm.getScrollInfo();
+    tab.cm.setValue(data.content);
+    tab.savedContent = data.content;
+    tab.cm.setCursor(cursor);
+    tab.cm.scrollTo(scroll.left, scroll.top);
+    removeReloadBar(path);
+  } catch {
+    // Silently ignore fetch errors (file may have been deleted)
+  }
+}
+
+// ── SSE connection ───────────────────────────────────────────────────────────
+
+let eventSource = null;
+
+export function connectSSE() {
+  if (eventSource) return;
+  eventSource = new EventSource("/api/events");
+
+  eventSource.onmessage = (e) => {
+    let event;
+    try {
+      event = JSON.parse(e.data);
+    } catch {
+      return;
+    }
+
+    const { type, path } = event;
+
+    if (type === "file_changed") {
+      const tab = state.tabs.get(path);
+      if (!tab) return; // File not open, nothing to do
+      const currentContent = tab.cm.getValue();
+      if (currentContent !== tab.savedContent) {
+        // Tab has unsaved edits — show notification
+        showReloadBar(path, tab.name);
+      } else {
+        // No local edits — silently reload
+        reloadTab(path);
+      }
+    } else if (type === "file_created" || type === "file_deleted") {
+      loadFileTree();
+    }
+  };
+
+  let errorCount = 0;
+  eventSource.onerror = () => {
+    errorCount++;
+    // EventSource auto-reconnects; if it fails repeatedly the server is gone
+    if (errorCount >= 3 && !document.getElementById("disconnected-banner")) {
+      showDisconnectedBanner();
+    }
+  };
+
+  eventSource.onopen = () => {
+    errorCount = 0;
+    const banner = document.getElementById("disconnected-banner");
+    if (banner) banner.remove();
+  };
+}
+
+// ── Disconnected banner ──────────────────────────────────────────────────────
+
+function showDisconnectedBanner() {
+  const banner = document.createElement("div");
+  banner.id = "disconnected-banner";
+  banner.textContent = "Server disconnected. Restart the web server and reload this page.";
+  document.body.prepend(banner);
+}

--- a/proof_frog/web/style.css
+++ b/proof_frog/web/style.css
@@ -343,6 +343,32 @@ select.wizard-input { cursor: pointer; }
 /* Error line highlight */
 .cm-error-line { background: rgba(244, 135, 113, 0.15) !important; }
 
+/* ── Reload notification bar ── */
+.reload-bar {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 14px; background: rgba(206,145,120,0.15);
+  border-bottom: 2px solid var(--warn);
+  font-size: 13px; font-weight: 600; color: var(--warn); flex-shrink: 0;
+  z-index: 10; position: relative;
+}
+.reload-bar button {
+  padding: 4px 12px; border: 1px solid var(--warn); border-radius: 3px;
+  background: var(--bg2); color: var(--warn); cursor: pointer; font-size: 12px;
+  font-weight: 600;
+}
+.reload-bar button:first-of-type { background: var(--warn); color: var(--bg); }
+.reload-bar button:first-of-type:hover { opacity: 0.85; }
+.reload-bar button:last-of-type:hover { background: var(--bg3); }
+
+/* ── Disconnected banner ── */
+#disconnected-banner {
+  background: var(--error); color: #fff; text-align: center;
+  padding: 10px 16px; font-size: 14px; font-weight: 700;
+  letter-spacing: 0.02em;
+  flex-shrink: 0; z-index: 9999;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+}
+
 /* ── Output pane ── */
 #output-pane {
   background: var(--bg2); border-top: 1px solid var(--border);

--- a/proof_frog/web_server.py
+++ b/proof_frog/web_server.py
@@ -1,18 +1,24 @@
+import atexit
 import copy
 import io
+import json
 import logging
 import os
+import queue
 import re
 import socket
 import threading
+import time
 import webbrowser
 from contextlib import redirect_stdout, redirect_stderr
 from pathlib import Path
 from typing import Any
 
 from sympy import Symbol
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler, FileSystemEvent
 
-from flask import Flask, request, jsonify, send_file, send_from_directory
+from flask import Flask, request, jsonify, send_file, send_from_directory, Response
 
 from . import frog_parser, frog_ast, proof_engine, semantic_analysis
 from . import describe as describe_module
@@ -531,7 +537,93 @@ def _build_tree(path: Path, base: Path) -> dict[str, object]:
     }
 
 
-def create_app(directory: str) -> Flask:
+_WATCHED_EXTENSIONS = {".primitive", ".scheme", ".game", ".proof", ".md"}
+_DEBOUNCE_SECONDS = 0.3
+
+
+class _FileEventBroker:
+    """Thread-safe broker that distributes filesystem events to SSE subscribers."""
+
+    def __init__(self) -> None:
+        self._subscribers: list[queue.Queue[dict[str, str]]] = []
+        self._lock = threading.Lock()
+
+    def subscribe(self) -> queue.Queue[dict[str, str]]:
+        q: queue.Queue[dict[str, str]] = queue.Queue()
+        with self._lock:
+            self._subscribers.append(q)
+        return q
+
+    def unsubscribe(self, q: queue.Queue[dict[str, str]]) -> None:
+        with self._lock:
+            try:
+                self._subscribers.remove(q)
+            except ValueError:
+                pass
+
+    def publish(self, event: dict[str, str]) -> None:
+        with self._lock:
+            for q in self._subscribers:
+                q.put(event)
+
+
+class _FrogFileHandler(FileSystemEventHandler):
+    """Debounced handler that publishes file change events to a broker."""
+
+    def __init__(self, broker: _FileEventBroker, base: Path) -> None:
+        super().__init__()
+        self._broker = broker
+        self._base = base
+        self._last_events: dict[str, float] = {}
+        self._lock = threading.Lock()
+
+    def _should_handle(self, path_str: str) -> bool:
+        p = Path(path_str)
+        if p.suffix not in _WATCHED_EXTENSIONS:
+            return False
+        try:
+            rel = p.relative_to(self._base)
+        except ValueError:
+            return False
+        return not any(part.startswith(".") for part in rel.parts)
+
+    def _debounced_publish(self, event_type: str, src_path: str) -> None:
+        now = time.monotonic()
+        key = f"{event_type}:{src_path}"
+        with self._lock:
+            last = self._last_events.get(key, 0.0)
+            if now - last < _DEBOUNCE_SECONDS:
+                return
+            self._last_events[key] = now
+        try:
+            rel = str(Path(src_path).relative_to(self._base))
+        except ValueError:
+            return
+        self._broker.publish({"type": event_type, "path": rel})
+
+    def on_modified(self, event: FileSystemEvent) -> None:
+        if not event.is_directory and self._should_handle(str(event.src_path)):
+            self._debounced_publish("file_changed", str(event.src_path))
+
+    def on_created(self, event: FileSystemEvent) -> None:
+        if not event.is_directory and self._should_handle(str(event.src_path)):
+            self._debounced_publish("file_created", str(event.src_path))
+
+    def on_deleted(self, event: FileSystemEvent) -> None:
+        if not event.is_directory and self._should_handle(str(event.src_path)):
+            self._debounced_publish("file_deleted", str(event.src_path))
+
+    def on_moved(self, event: FileSystemEvent) -> None:
+        src = str(event.src_path)
+        dest = str(getattr(event, "dest_path", ""))
+        if not event.is_directory:
+            if self._should_handle(src):
+                self._debounced_publish("file_deleted", src)
+            if dest and self._should_handle(dest):
+                self._debounced_publish("file_created", dest)
+
+
+def create_app(directory: str, *, watch: bool = True) -> tuple[Flask, Any]:
     app = Flask(__name__, static_folder=None)
     app.config["MAX_CONTENT_LENGTH"] = 16 * 1024 * 1024  # 16 MB
     static_dir = Path(__file__).parent / "web"
@@ -774,7 +866,42 @@ def create_app(directory: str) -> Flask:
         except Exception as e:  # pylint: disable=broad-exception-caught
             return jsonify({"error": f"Error: {e}"}), 400
 
-    return app
+    # ── File watcher + SSE ──────────────────────────────────────────────────
+
+    broker = _FileEventBroker()
+    observer: Any = None
+    if watch:
+        base_path = Path(directory).resolve()
+        handler = _FrogFileHandler(broker, base_path)
+        observer = Observer()
+        observer.schedule(handler, str(base_path), recursive=True)
+        observer.start()
+
+    @app.route("/api/events")
+    def sse_events() -> Any:
+        def _stream() -> Any:
+            q = broker.subscribe()
+            try:
+                while True:
+                    try:
+                        event = q.get(timeout=15)
+                        yield f"data: {json.dumps(event)}\n\n"
+                    except queue.Empty:
+                        # Heartbeat to keep connection alive
+                        yield ": heartbeat\n\n"
+            except GeneratorExit:
+                broker.unsubscribe(q)
+
+        return Response(
+            _stream(),
+            mimetype="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+            },
+        )
+
+    return app, observer
 
 
 def start_server(directory: str) -> None:
@@ -783,7 +910,8 @@ def start_server(directory: str) -> None:
         print(f"Error: '{directory}' is not a directory", flush=True)
         return
 
-    app = create_app(directory)
+    app, observer = create_app(directory)
+    atexit.register(observer.stop)
     port = _find_free_port(5173)
     url = f"http://127.0.0.1:{port}"
 
@@ -796,4 +924,8 @@ def start_server(directory: str) -> None:
     log = logging.getLogger("werkzeug")
     log.setLevel(logging.ERROR)
 
-    app.run(host="127.0.0.1", port=port, debug=False)
+    try:
+        app.run(host="127.0.0.1", port=port, debug=False)
+    finally:
+        observer.stop()
+        observer.join()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 	"z3-solver >= 4.12",
 	"sympy >= 1.12",
 	"flask >= 3.0",
+	"watchdog >= 4.0",
 	"click >= 8.0",
 	"pygls >= 1.3"
 ]
@@ -82,6 +83,9 @@ module='pygls.*'
 ignore_missing_imports = 'True'
 [[tool.mypy.overrides]]
 module='lsprotocol.*'
+ignore_missing_imports = 'True'
+[[tool.mypy.overrides]]
+module='watchdog.*'
 ignore_missing_imports = 'True'
 
 [tool.pylint.MASTER]

--- a/tests/integration/test_file_metadata.py
+++ b/tests/integration/test_file_metadata.py
@@ -11,7 +11,7 @@ from proof_frog.web_server import create_app
 def client():
     """Flask test client rooted at the examples directory."""
     examples_dir = os.path.join(os.path.dirname(__file__), "..", "..", "examples")
-    app = create_app(os.path.abspath(examples_dir))
+    app, _observer = create_app(os.path.abspath(examples_dir), watch=False)
     app.config["TESTING"] = True
     with app.test_client() as c:
         yield c


### PR DESCRIPTION
Watch the working directory for file changes using watchdog and push events to the browser over Server-Sent Events.  When a file changes on disk, open tabs are silently reloaded (or a notification bar is shown if there are unsaved edits).  A prominent banner appears when the server is disconnected.