### PR TITLE
Engine fixes for KEM CCA proofs: alias propagation, duplicate fields, tuple collapse

### DIFF
--- a/proof_frog/dependencies.py
+++ b/proof_frog/dependencies.py
@@ -119,6 +119,13 @@ class DependencyGraph:
         self.nodes.append(new_node)
 
     def get_node(self, statement: frog_ast.Statement) -> Node:
+        # Prefer identity match to avoid returning the wrong node when
+        # two structurally-equal statements exist (e.g. duplicate
+        # if-conditions).  Fall back to equality for callers that pass
+        # a copy.
+        for potential_node in self.nodes:
+            if potential_node.statement is statement:
+                return potential_node
         for potential_node in self.nodes:
             if potential_node.statement == statement:
                 return potential_node

--- a/proof_frog/proof_engine.py
+++ b/proof_frog/proof_engine.py
@@ -1069,15 +1069,17 @@ class ProofEngine:
             )
 
         dfs_stack: list[dependencies.Node] = []
-        dfs_stack_visited = [False] * len(block.statements)
+        # Use identity-keyed visited set to handle duplicate statements
+        dfs_visited_ids: set[int] = set()
         dfs_sorted_statements: list[frog_ast.Statement] = []
 
         def do_dfs() -> None:
             while dfs_stack:
                 node = dfs_stack.pop()
-                if not dfs_stack_visited[block.statements.index(node.statement)]:
+                stmt_id = id(node.statement)
+                if stmt_id not in dfs_visited_ids:
                     dfs_sorted_statements.append(node.statement)
-                    dfs_stack_visited[block.statements.index(node.statement)] = True
+                    dfs_visited_ids.add(stmt_id)
                     for neighbour in node.in_neighbours:
                         dfs_stack.append(neighbour)
 
@@ -1096,7 +1098,7 @@ class ProofEngine:
                 ]
 
             found = visitors.SearchVisitor(uses_field).visit(statement)
-            if statement not in dfs_sorted_statements and found is not None:
+            if id(statement) not in dfs_visited_ids and found is not None:
                 dfs_stack.append(graph.get_node(statement))
                 do_dfs()
 

--- a/proof_frog/transforms/control_flow.py
+++ b/proof_frog/transforms/control_flow.py
@@ -297,15 +297,66 @@ class RemoveUnreachableTransformer(BlockTransformer):
 
         formula_visitor = Z3FormulaVisitor(NameTypeMap())
 
+        # Track if-conditions with unconditional returns that have
+        # already been seen.  A subsequent if with the same condition
+        # is dead code (the earlier check already returned).
+        seen_return_conditions: list[frog_ast.Expression] = []
+        dead_indices: list[int] = []
         for index, statement in enumerate(block.statements):
             if not isinstance(statement, frog_ast.IfStatement):
+                old_versions = dict(variable_version_map)
                 update_version(statement)
+                # If any variable was modified, invalidate syntactic
+                # condition tracking (the same expression may now
+                # evaluate differently).
+                if variable_version_map != old_versions:
+                    seen_return_conditions.clear()
                 continue
 
             if statement.has_else_block() and all(
                 contains_unconditional_return(if_block) for if_block in statement.blocks
             ):
-                return frog_ast.Block(block.statements[: index + 1])
+                new_stmts = [
+                    s
+                    for i, s in enumerate(block.statements[: index + 1])
+                    if i not in dead_indices
+                ]
+                return frog_ast.Block(new_stmts)
+
+            # Syntactic check: if all conditions match a previously-seen
+            # return condition AND the if has an unconditional return and
+            # no else, the if-statement is dead.
+            if (
+                not statement.has_else_block()
+                and all(contains_unconditional_return(b) for b in statement.blocks)
+                and all(cond in seen_return_conditions for cond in statement.conditions)
+            ):
+                dead_indices.append(index)
+                continue
+
+            # Z3-based check for more complex subsumption
+            if formula_so_far is not None and not statement.has_else_block():
+                type_map = GetTypeMapVisitor(statement).visit(self.ast)
+                formula_visitor.set_type_map(type_map)
+                formula_visitor.set_variable_version_map(variable_version_map)
+                all_conditions_dead = True
+                for condition in statement.conditions:
+                    cond_formula = formula_visitor.visit(condition)
+                    if cond_formula is None:
+                        all_conditions_dead = False
+                        break
+                    dead_solver = z3.Solver()
+                    dead_solver.set("timeout", 30000)
+                    dead_solver.add(z3.And(z3.Not(formula_so_far), cond_formula))
+                    if dead_solver.check() != z3.unsat:
+                        all_conditions_dead = False
+                        break
+                if all_conditions_dead and all(
+                    contains_unconditional_return(b) for b in statement.blocks
+                ):
+                    dead_indices.append(index)
+                    continue
+
             solver = z3.Solver()
             solver.set("timeout", 30000)
 
@@ -336,14 +387,28 @@ class RemoveUnreachableTransformer(BlockTransformer):
                     )
                 condition_formulae.append(individual_formula)
 
+            # Track conditions that lead to unconditional returns
+            for condition_index, condition in enumerate(statement.conditions):
+                if contains_unconditional_return(statement.blocks[condition_index]):
+                    seen_return_conditions.append(condition)
+
             update_version(statement)
             if formula_so_far is not None:
                 solver.add(z3.Not(formula_so_far))
             satisfiable = solver.check()
             solver.reset()
             if satisfiable == z3.unsat:
-                return frog_ast.Block(block.statements[: index + 1])
+                new_stmts = [
+                    s
+                    for i, s in enumerate(block.statements[: index + 1])
+                    if i not in dead_indices
+                ]
+                return frog_ast.Block(new_stmts)
 
+        if dead_indices:
+            return frog_ast.Block(
+                [s for i, s in enumerate(block.statements) if i not in dead_indices]
+            )
         return block
 
 

--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -517,9 +517,16 @@ class RedundantFieldCopyTransformer(BlockTransformer):
                         decl_index = other_index
                         decl_statement = other_statement
                         continue
+                    # Check that the local variable being copied has no
+                    # other uses besides the field assignment and its
+                    # own declaration.  We must check uses of the local
+                    # variable (statement.value), not the field
+                    # (statement.var), to avoid leaving dangling
+                    # references when the local is also used elsewhere.
+                    assert isinstance(statement.value, frog_ast.Variable)
                     if (
                         SearchVisitor(
-                            functools.partial(search_for_other_use, statement.var)
+                            functools.partial(search_for_other_use, statement.value)
                         ).visit(other_statement)
                         is not None
                     ):
@@ -546,10 +553,10 @@ class RedundantFieldCopyTransformer(BlockTransformer):
 class ForwardExpressionAliasTransformer(BlockTransformer):
     """Replaces repeated pure expressions with their named variable.
 
-    When a typed assignment ``Type v = expr`` defines a named alias for a
-    deterministic expression (no function calls) that is not a plain variable
-    or tuple literal, subsequent structurally-identical occurrences of
-    ``expr`` are replaced with ``v``.
+    When an assignment ``v = expr`` (typed local or field assignment) defines
+    a named alias for a deterministic expression (no function calls) that is
+    not a plain variable or tuple literal, subsequent structurally-identical
+    occurrences of ``expr`` are replaced with ``v``.
 
     This is safe because the expression is deterministic and neither ``v``
     nor any free variable in ``expr`` is reassigned between the definition
@@ -566,15 +573,92 @@ class ForwardExpressionAliasTransformer(BlockTransformer):
         return F(v3, v3);
     """
 
+    def __init__(self) -> None:
+        self.fields: list[str] = []
+
+    def transform_game(self, game: frog_ast.Game) -> frog_ast.Game:
+        self.fields = [field.name for field in game.fields]
+        new_game = copy.deepcopy(game)
+        new_game.methods = [self.transform(method) for method in new_game.methods]
+        return new_game
+
     def _transform_block_wrapper(self, block: frog_ast.Block) -> frog_ast.Block:
         for index, statement in enumerate(block.statements):
-            if not (
+            is_typed_decl = (
                 isinstance(statement, frog_ast.Assignment)
                 and statement.the_type is not None
                 and isinstance(statement.var, frog_ast.Variable)
-                and not isinstance(statement.value, frog_ast.Variable)
-                and not isinstance(statement.value, frog_ast.Tuple)
-            ):
+            )
+            is_field_assign = (
+                isinstance(statement, frog_ast.Assignment)
+                and statement.the_type is None
+                and isinstance(statement.var, frog_ast.Variable)
+                and statement.var.name in self.fields
+            )
+            if not (is_typed_decl or is_field_assign):
+                continue
+            assert isinstance(statement, frog_ast.Assignment)
+            assert isinstance(statement.var, frog_ast.Variable)
+            # For field assignments from a variable (field = v or
+            # field1 = field2), propagate the source name → field name
+            # in subsequent code.
+            if is_field_assign and isinstance(statement.value, frog_ast.Variable):
+                local_name = statement.value.name
+                field_name = statement.var.name
+                remaining_block = frog_ast.Block(
+                    copy.deepcopy(block.statements[index + 1 :])
+                )
+
+                def is_written_to_fv(name: str, node: frog_ast.ASTNode) -> bool:
+                    return (
+                        isinstance(
+                            node,
+                            (
+                                frog_ast.Sample,
+                                frog_ast.Assignment,
+                                frog_ast.UniqueSample,
+                            ),
+                        )
+                        and isinstance(node.var, frog_ast.Variable)
+                        and node.var.name == name
+                    )
+
+                # Only propagate if the local is not reassigned after
+                if (
+                    SearchVisitor(
+                        functools.partial(is_written_to_fv, local_name)
+                    ).visit(remaining_block)
+                    is not None
+                ):
+                    continue
+                # And the field is not reassigned after
+                if (
+                    SearchVisitor(
+                        functools.partial(is_written_to_fv, field_name)
+                    ).visit(remaining_block)
+                    is not None
+                ):
+                    continue
+
+                # Find and replace one occurrence of the local variable
+                def matches_local(name: str, node: frog_ast.ASTNode) -> bool:
+                    return isinstance(node, frog_ast.Variable) and node.name == name
+
+                match = SearchVisitor(
+                    functools.partial(matches_local, local_name)
+                ).visit(remaining_block)
+                if match is not None:
+                    remaining_block = ReplaceTransformer(
+                        match, frog_ast.Variable(field_name)
+                    ).transform(remaining_block)
+                    return self._transform_block_wrapper(
+                        frog_ast.Block(
+                            copy.deepcopy(block.statements[: index + 1])
+                            + list(remaining_block.statements)
+                        )
+                    )
+                continue
+            if isinstance(statement.value, (frog_ast.Variable, frog_ast.Tuple)):
                 continue
 
             var_name = statement.var.name

--- a/proof_frog/transforms/pipelines.py
+++ b/proof_frog/transforms/pipelines.py
@@ -46,7 +46,12 @@ from .control_flow import (
     RemoveUnreachable,
 )
 from .types import DeadNullGuardElimination, SubsetTypeNormalization
-from .tuples import FoldTupleIndex, ExpandTuple, SimplifyTuple
+from .tuples import (
+    FoldTupleIndex,
+    ExpandTuple,
+    SimplifyTuple,
+    CollapseSingleIndexTuple,
+)
 from .standardization import (
     VariableStandardize,
     StandardizeFieldNames,
@@ -81,6 +86,7 @@ CORE_PIPELINE: list[TransformPass] = [
     SimplifyIf(),
     DeadNullGuardElimination(),
     SubsetTypeNormalization(),
+    CollapseSingleIndexTuple(),
     ExpandTuple(),
     SimplifyNotPass(),
     XorCancellation(),

--- a/proof_frog/transforms/tuples.py
+++ b/proof_frog/transforms/tuples.py
@@ -10,8 +10,11 @@ import copy
 
 from .. import frog_ast
 from ..visitors import (
+    BlockTransformer,
     Transformer,
+    Visitor,
     SearchVisitor,
+    ReplaceTransformer,
     AllConstantFieldAccesses,
     GetTypeMapVisitor,
 )
@@ -265,3 +268,121 @@ class SimplifyTuple(TransformPass):
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
         return SimplifyTupleTransformer(game).transform(game)
+
+
+class CollapseSingleIndexTupleTransformer(BlockTransformer):
+    """Collapses a product-typed variable accessed at a single constant index.
+
+    When a typed local ``[T0, T1] v = expr`` (where *expr* is not a tuple
+    literal) is only ever used as ``v[i]`` for one fixed index *i*, it is
+    rewritten to ``Ti v = expr[i]`` and every ``v[i]`` is replaced with ``v``.
+
+    This normalises composed-game canonical forms where a function call
+    returning a product is only partially used, matching the form produced
+    when a scheme-inlined game drops unused components.
+    """
+
+    @staticmethod
+    def _analyse_uses(var_name: str, block: frog_ast.Block) -> tuple[bool, set[int]]:
+        """Return (has_bare_use, indices_used) for *var_name* in *block*.
+
+        A "bare use" is any ``Variable(var_name)`` that is NOT the
+        ``the_array`` child of an ``ArrayAccess`` node.
+        """
+
+        class _UsageVisitor(Visitor[None]):
+            """Count total Variable refs and ArrayAccess refs."""
+
+            def __init__(self, name: str) -> None:
+                self.name = name
+                self.total_var_refs = 0
+                self.array_access_refs = 0
+                self.indices: set[int] = set()
+
+            def result(self) -> None:
+                pass
+
+            def visit_variable(self, var: frog_ast.Variable) -> None:
+                if var.name == self.name:
+                    self.total_var_refs += 1
+
+            def visit_array_access(self, aa: frog_ast.ArrayAccess) -> None:
+                if (
+                    isinstance(aa.the_array, frog_ast.Variable)
+                    and aa.the_array.name == self.name
+                ):
+                    self.array_access_refs += 1
+                    if isinstance(aa.index, frog_ast.Integer):
+                        self.indices.add(aa.index.num)
+
+        visitor = _UsageVisitor(var_name)
+        visitor.visit(block)
+        # Bare uses = total Variable refs minus those inside ArrayAccess
+        has_bare = visitor.total_var_refs > visitor.array_access_refs
+        return has_bare, visitor.indices
+
+    def _transform_block_wrapper(self, block: frog_ast.Block) -> frog_ast.Block:
+        for stmt_idx, statement in enumerate(block.statements):
+            if not (
+                isinstance(statement, frog_ast.Assignment)
+                and statement.the_type is not None
+                and isinstance(statement.the_type, frog_ast.ProductType)
+                and isinstance(statement.var, frog_ast.Variable)
+                and not isinstance(statement.value, frog_ast.Tuple)
+            ):
+                continue
+
+            var_name = statement.var.name
+            remaining = frog_ast.Block(list(block.statements[stmt_idx + 1 :]))
+
+            has_bare, indices_used = self._analyse_uses(var_name, remaining)
+            if has_bare or len(indices_used) != 1:
+                continue
+
+            idx = next(iter(indices_used))
+            assert isinstance(statement.the_type, frog_ast.ProductType)
+            element_type = statement.the_type.types[idx]
+
+            # Rewrite the declaration to extract just one element
+            new_decl = frog_ast.Assignment(
+                element_type,
+                frog_ast.Variable(var_name),
+                frog_ast.ArrayAccess(
+                    copy.deepcopy(statement.value),
+                    frog_ast.Integer(idx),
+                ),
+            )
+
+            new_stmts = (
+                list(block.statements[:stmt_idx])
+                + [new_decl]
+                + list(block.statements[stmt_idx + 1 :])
+            )
+            new_block = frog_ast.Block(new_stmts)
+
+            # Replace all ArrayAccess(v, idx) with Variable(v)
+            target = frog_ast.ArrayAccess(
+                frog_ast.Variable(var_name), frog_ast.Integer(idx)
+            )
+            while True:
+                found = SearchVisitor(
+                    lambda n, t=target: (  # type: ignore[misc]
+                        isinstance(n, frog_ast.ArrayAccess) and n == t
+                    )
+                ).visit(new_block)
+                if found is None:
+                    break
+                new_block = ReplaceTransformer(
+                    found, frog_ast.Variable(var_name)
+                ).transform(new_block)
+
+            return self.transform(new_block)
+
+        return block
+
+
+class CollapseSingleIndexTuple(TransformPass):
+    name = "Collapse Single-Index Tuple Access"
+
+    def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
+        return CollapseSingleIndexTupleTransformer().transform(game)

--- a/proof_frog/visitors.py
+++ b/proof_frog/visitors.py
@@ -789,15 +789,46 @@ class SameFieldVisitor(Visitor[Optional[list[frog_ast.Statement]]]):
             def contains_func(node: frog_ast.ASTNode) -> bool:
                 return isinstance(node, frog_ast.FuncCall)
 
-            if SearchVisitor(contains_func).visit(statement) is not None or isinstance(
-                statement, frog_ast.Sample
-            ):
+            has_func_call = SearchVisitor(contains_func).visit(
+                statement
+            ) is not None or isinstance(statement, frog_ast.Sample)
+
+            if has_func_call:
+                # Assignments with function calls can't be matched by
+                # expression equality (the call may return different
+                # values each time).  However, a direct copy of the
+                # field IS safe: field1 = K.f(); field2 = field1.
+                def reads_pair_fc(pn: str, node: frog_ast.ASTNode) -> bool:
+                    return isinstance(node, frog_ast.Variable) and node.name == pn
+
+                copy_paired = False
+                for subsequent_statement in block.statements[index + 1 :]:
+                    if (
+                        isinstance(subsequent_statement, frog_ast.Assignment)
+                        and isinstance(subsequent_statement.var, frog_ast.Variable)
+                        and subsequent_statement.var.name == pair_name
+                        and isinstance(subsequent_statement.value, frog_ast.Variable)
+                        and subsequent_statement.value.name == assigned_name
+                    ):
+                        copy_paired = True
+                        self.paired_statements.append(subsequent_statement)
+                        break
+                    if (
+                        SearchVisitor(
+                            functools.partial(reads_pair_fc, pair_name)
+                        ).visit(subsequent_statement)
+                        is not None
+                    ):
+                        break
+                if copy_paired:
+                    continue
                 self.are_same = False
                 return
 
             def reads_pair(pair_name: str, node: frog_ast.ASTNode) -> bool:
                 return isinstance(node, frog_ast.Variable) and node.name == pair_name
 
+            assert isinstance(statement, frog_ast.Assignment)
             used_variables = VariableCollectionVisitor().visit(statement.value)
 
             assigns_variable_partial = functools.partial(

--- a/tests/unit/transforms/test_collapse_single_index_tuple.py
+++ b/tests/unit/transforms/test_collapse_single_index_tuple.py
@@ -1,0 +1,93 @@
+import pytest
+from proof_frog import frog_parser, frog_ast
+from proof_frog.transforms.tuples import CollapseSingleIndexTupleTransformer
+
+
+@pytest.mark.parametrize(
+    "method,expected_stmts",
+    [
+        # Core case: only v[1] is used, collapse to scalar
+        # Expected: v becomes scalar typed, v[1] replaced with v
+        (
+            """
+            Int f() {
+                [Int, Int] v = challenger.g();
+                return v[1];
+            }
+            """,
+            2,  # assignment + return, v is now scalar
+        ),
+        # Only v[0] is used
+        (
+            """
+            Int f() {
+                [Int, Int] v = challenger.g();
+                return v[0];
+            }
+            """,
+            2,
+        ),
+        # Multiple uses of same index — still collapse
+        (
+            """
+            Int f() {
+                [Int, Int] v = challenger.g();
+                Int a = v[1];
+                return a + v[1];
+            }
+            """,
+            3,  # collapsed v decl + a decl + return
+        ),
+    ],
+)
+def test_collapse_single_index_tuple_fires(
+    method: str,
+    expected_stmts: int,
+) -> None:
+    """Verify the transform fires and produces the right number of statements."""
+    method_ast = frog_parser.parse_method(method)
+    transformed = CollapseSingleIndexTupleTransformer().transform(method_ast)
+    assert len(transformed.block.statements) == expected_stmts
+    # After collapse, the declaration should have a non-product type
+    first_stmt = transformed.block.statements[0]
+    assert isinstance(first_stmt, frog_ast.Assignment)
+    assert not isinstance(first_stmt.the_type, frog_ast.ProductType)
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        # Should NOT transform: both indices used
+        """
+        Int f() {
+            [Int, Int] v = challenger.g();
+            return v[0] + v[1];
+        }
+        """,
+        # Should NOT transform: bare variable use
+        """
+        [Int, Int] f() {
+            [Int, Int] v = challenger.g();
+            return v;
+        }
+        """,
+        # Should NOT transform: value is a tuple literal (handled by ExpandTuple)
+        """
+        Int f() {
+            [Int, Int] v = [1, 2];
+            return v[1];
+        }
+        """,
+        # Should NOT transform: no type annotation (parameter, not declaration)
+        """
+        Int f([Int, Int] v) {
+            return v[1];
+        }
+        """,
+    ],
+)
+def test_collapse_single_index_tuple_no_change(method: str) -> None:
+    """Verify the transform does NOT fire for these cases."""
+    method_ast = frog_parser.parse_method(method)
+    transformed = CollapseSingleIndexTupleTransformer().transform(method_ast)
+    assert transformed == method_ast

--- a/tests/unit/transforms/test_forward_expression_alias.py
+++ b/tests/unit/transforms/test_forward_expression_alias.py
@@ -158,3 +158,107 @@ def test_forward_expression_alias(
 
     transformed_ast = ForwardExpressionAliasTransformer().transform(game_ast)
     assert expected_ast == transformed_ast
+
+
+@pytest.mark.parametrize(
+    "game,expected",
+    [
+        # Field assignment propagates expression alias to subsequent code
+        (
+            """
+        Game Test() {
+            Int field1;
+            Void Initialize() {
+                [Int, Int] x = challenger.g();
+                field1 = x[0];
+                Int v = x[0];
+            }
+        }""",
+            """
+        Game Test() {
+            Int field1;
+            Void Initialize() {
+                [Int, Int] x = challenger.g();
+                field1 = x[0];
+                Int v = field1;
+            }
+        }""",
+        ),
+        # Field-from-variable copy: field1 = v propagates v -> field1
+        (
+            """
+        Game Test() {
+            Int field1;
+            Int Initialize() {
+                Int v = challenger.g();
+                field1 = v;
+                return v;
+            }
+        }""",
+            """
+        Game Test() {
+            Int field1;
+            Int Initialize() {
+                Int v = challenger.g();
+                field1 = v;
+                return field1;
+            }
+        }""",
+        ),
+        # Should NOT propagate: local is reassigned after field copy
+        (
+            """
+        Game Test() {
+            Int field1;
+            Int Initialize() {
+                Int v = 1;
+                field1 = v;
+                v = 2;
+                return v;
+            }
+        }""",
+            """
+        Game Test() {
+            Int field1;
+            Int Initialize() {
+                Int v = 1;
+                field1 = v;
+                v = 2;
+                return v;
+            }
+        }""",
+        ),
+        # Should NOT propagate: field is reassigned after copy
+        (
+            """
+        Game Test() {
+            Int field1;
+            Int Initialize() {
+                Int v = 1;
+                field1 = v;
+                field1 = 2;
+                return v;
+            }
+        }""",
+            """
+        Game Test() {
+            Int field1;
+            Int Initialize() {
+                Int v = 1;
+                field1 = v;
+                field1 = 2;
+                return v;
+            }
+        }""",
+        ),
+    ],
+)
+def test_forward_expression_alias_field(
+    game: str,
+    expected: str,
+) -> None:
+    game_ast = frog_parser.parse_game(game)
+    expected_ast = frog_parser.parse_game(expected)
+
+    transformed_ast = ForwardExpressionAliasTransformer().transform(game_ast)
+    assert expected_ast == transformed_ast

--- a/tests/unit/transforms/test_redundant_field_copy.py
+++ b/tests/unit/transforms/test_redundant_field_copy.py
@@ -1,0 +1,121 @@
+import pytest
+from proof_frog import frog_parser
+from proof_frog.transforms.inlining import RedundantFieldCopyTransformer
+
+
+@pytest.mark.parametrize(
+    "game,expected",
+    [
+        # Core case: local only used in field copy, should be inlined
+        (
+            """
+        Game Test() {
+            Int field1;
+            Void Initialize() {
+                Int v <- Int;
+                field1 = v;
+            }
+        }""",
+            """
+        Game Test() {
+            Int field1;
+            Void Initialize() {
+                field1 <- Int;
+            }
+        }""",
+        ),
+        # Local used in field copy AND return — must NOT inline
+        # (would leave dangling reference)
+        (
+            """
+        Game Test() {
+            Int field1;
+            Int Initialize() {
+                Int v <- Int;
+                field1 = v;
+                return v;
+            }
+        }""",
+            """
+        Game Test() {
+            Int field1;
+            Int Initialize() {
+                Int v <- Int;
+                field1 = v;
+                return v;
+            }
+        }""",
+        ),
+        # Local used in field copy AND another expression — must NOT inline
+        (
+            """
+        Game Test() {
+            Int field1;
+            Int Initialize() {
+                Int v = challenger.g();
+                field1 = v;
+                return v + 1;
+            }
+        }""",
+            """
+        Game Test() {
+            Int field1;
+            Int Initialize() {
+                Int v = challenger.g();
+                field1 = v;
+                return v + 1;
+            }
+        }""",
+        ),
+        # Assignment (not sample) — local only used in field copy
+        (
+            """
+        Game Test() {
+            Int field1;
+            Int Initialize() {
+                Int v = 42;
+                field1 = v;
+                return field1;
+            }
+        }""",
+            """
+        Game Test() {
+            Int field1;
+            Int Initialize() {
+                field1 = 42;
+                return field1;
+            }
+        }""",
+        ),
+        # RHS is a field, not a local — should NOT transform
+        (
+            """
+        Game Test() {
+            Int field1;
+            Int field2;
+            Void Initialize() {
+                field1 = 5;
+                field2 = field1;
+            }
+        }""",
+            """
+        Game Test() {
+            Int field1;
+            Int field2;
+            Void Initialize() {
+                field1 = 5;
+                field2 = field1;
+            }
+        }""",
+        ),
+    ],
+)
+def test_redundant_field_copy(
+    game: str,
+    expected: str,
+) -> None:
+    game_ast = frog_parser.parse_game(game)
+    expected_ast = frog_parser.parse_game(expected)
+
+    transformed_ast = RedundantFieldCopyTransformer().transform(game_ast)
+    assert transformed_ast == expected_ast

--- a/tests/unit/transforms/test_remove_duplicate_fields.py
+++ b/tests/unit/transforms/test_remove_duplicate_fields.py
@@ -139,6 +139,59 @@ from proof_frog import proof_engine, frog_parser
             }
         }""",
         ),
+        # Direct field copy after function call: field1 = f(); field2 = field1
+        # should be merged (the copy is safe, doesn't replicate the call)
+        (
+            """
+        Game Test() {
+            Int field1;
+            Int field2;
+            Void Initialize() {
+                field1 = challenger.g();
+                field2 = field1;
+            }
+            Int f() {
+                return field1 + field2;
+            }
+        }""",
+            """
+        Game Test() {
+            Int field1;
+            Void Initialize() {
+                field1 = challenger.g();
+            }
+            Int f() {
+                return field1 + field1;
+            }
+        }""",
+        ),
+        # Two independent function calls should NOT be merged
+        (
+            """
+        Game Test() {
+            Int field1;
+            Int field2;
+            Void Initialize() {
+                field1 = challenger.g();
+                field2 = challenger.g();
+            }
+            Int f() {
+                return field1 + field2;
+            }
+        }""",
+            """
+        Game Test() {
+            Int field1;
+            Int field2;
+            Void Initialize() {
+                field1 = challenger.g();
+                field2 = challenger.g();
+            }
+            Int f() {
+                return field1 + field2;
+            }
+        }""",
+        ),
     ],
 )
 def test_remove_duplicate_fields(

--- a/tests/unit/transforms/test_unreachable_transformer.py
+++ b/tests/unit/transforms/test_unreachable_transformer.py
@@ -352,6 +352,104 @@ from proof_frog.transforms.control_flow import RemoveUnreachableTransformer
             }
             """,
         ),
+        # Duplicate if-condition with return: second check is dead code
+        (
+            """
+            Int f(Int x) {
+                if (x == 0) {
+                    return 1;
+                }
+                if (x == 0) {
+                    return 2;
+                }
+                return 3;
+            }
+            """,
+            """
+            Int f(Int x) {
+                if (x == 0) {
+                    return 1;
+                }
+                return 3;
+            }
+            """,
+        ),
+        # Duplicate if-condition with intervening statement
+        (
+            """
+            Int f(Int x) {
+                if (x == 0) {
+                    return 1;
+                }
+                Int y = x + 1;
+                if (x == 0) {
+                    return 2;
+                }
+                return y;
+            }
+            """,
+            """
+            Int f(Int x) {
+                if (x == 0) {
+                    return 1;
+                }
+                Int y = x + 1;
+                return y;
+            }
+            """,
+        ),
+        # Should NOT eliminate: variable reassigned between checks
+        (
+            """
+            Int f(Int x) {
+                if (x == 0) {
+                    return 1;
+                }
+                x = x + 1;
+                if (x == 0) {
+                    return 2;
+                }
+                return 3;
+            }
+            """,
+            """
+            Int f(Int x) {
+                if (x == 0) {
+                    return 1;
+                }
+                x = x + 1;
+                if (x == 0) {
+                    return 2;
+                }
+                return 3;
+            }
+            """,
+        ),
+        # Should NOT eliminate: first if doesn't return
+        (
+            """
+            Int f(Int x) {
+                if (x == 0) {
+                    x = 5;
+                }
+                if (x == 0) {
+                    return 2;
+                }
+                return 3;
+            }
+            """,
+            """
+            Int f(Int x) {
+                if (x == 0) {
+                    x = 5;
+                }
+                if (x == 0) {
+                    return 2;
+                }
+                return 3;
+            }
+            """,
+        ),
     ],
 )
 def test_unreachable_transformer(

--- a/tests/unit/visitors/test_same_field_visitor.py
+++ b/tests/unit/visitors/test_same_field_visitor.py
@@ -196,6 +196,55 @@ from proof_frog import visitors, frog_parser
             ("x", "y"),
             False,
         ),
+        # Direct field copy after function call: field1 = f(); field2 = field1
+        # This IS a valid duplicate — the copy doesn't replicate the call.
+        (
+            """
+            Game G() {
+                Int field1;
+                Int field2;
+                Void f() {
+                    field1 = challenger.g();
+                    field2 = field1;
+                }
+            }
+            """,
+            ("field1", "field2"),
+            True,
+        ),
+        # Two independent function calls — NOT the same
+        # (each call may return a different value)
+        (
+            """
+            Game G() {
+                Int field1;
+                Int field2;
+                Void f() {
+                    field1 = challenger.g();
+                    field2 = challenger.h();
+                }
+            }
+            """,
+            ("field1", "field2"),
+            False,
+        ),
+        # Direct copy but pair field read before copy — NOT safe
+        (
+            """
+            Game G() {
+                Int field1;
+                Int field2;
+                Int f() {
+                    field1 = challenger.g();
+                    Int x = field2;
+                    field2 = field1;
+                    return x;
+                }
+            }
+            """,
+            ("field1", "field2"),
+            False,
+        ),
     ],
 )
 def test_same_field_visitor(game: str, pair: tuple[str, str], expected: bool) -> None:


### PR DESCRIPTION
Fix several canonicalization bugs exposed by the KEMPRF IND-CCA proof, where the Decaps oracle creates coordinated state (ctStar, sk) between the reduction and challenger after inlining.

- RedundantFieldCopyTransformer: check uses of the local variable, not the field, to avoid leaving dangling references when the local is also used in expressions beyond the field assignment
- ForwardExpressionAliasTransformer: propagate aliases from field assignments and field-from-variable copies (field1 = v -> replace subsequent v with field1), enabling cross-expression alias detection
- CollapseSingleIndexTupleTransformer: new pass that rewrites [T0,T1] v = f() to Ti v = f()[i] when only one index is accessed, normalizing partially-used function-call results
- DependencyGraph.get_node: prefer identity over equality to prevent self-loops when duplicate statements exist after field merging
- sort_block DFS: use id()-based visited tracking for the same reason
- SameFieldVisitor: recognize direct field copies (field2 = field1) even when the source assignment contains a function call
- RemoveUnreachableTransformer: eliminate if-conditions that duplicate a previously-seen return guard in the same block