### PR TITLE
Add CLI introspection commands for proof debugging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ python3 -m venv .venv
 - **Run tests**: `pytest` (runs in parallel via `pytest-xdist` `-n auto` by default; use `-n0` to disable)
 - **All CI checks**: `make lint` — runs `black --check`, `mypy`, and `pylint` in sequence (must all pass before committing)
 - **Auto-format**: `make format` — runs `black` to reformat in place, then re-run `make lint`
-- **CLI**: `python -m proof_frog [parse|check|prove|web|lsp] <file>`
+- **CLI**: `python -m proof_frog [parse|check|prove|describe|step-detail|inlined-game|canonicalization-trace|step-after-transform|web|lsp|mcp] <file>`
 - **Build VSCode extension**: `make vscode-extension`
 - **Package VSCode extension**: `make vscode-vsix`
 - **Regenerate parser**: `make parser` — regenerates ANTLR parsing code from grammar files into `proof_frog/parsing/`
@@ -37,7 +37,7 @@ The CI runs three checks on every push/PR to `main`. Always run `make lint` loca
 
 ## Architecture
 
-- `proof_frog/proof_frog.py` — CLI entry point (`parse`, `check`, `prove`, `web` commands)
+- `proof_frog/proof_frog.py` — CLI entry point (`parse`, `check`, `prove`, `describe`, `step-detail`, `inlined-game`, `canonicalization-trace`, `step-after-transform`, `web`, `lsp`, `mcp` commands)
 - `proof_frog/frog_ast.py` — AST node definitions
 - `proof_frog/frog_parser.py` — ANTLR-based parser
 - `proof_frog/proof_engine.py` — Proof verification (Z3 + SymPy)
@@ -114,7 +114,7 @@ When modifying the proof engine, be careful to ensure that transformations prese
 - **Naming**: Use naming conventions from the cryptographic literature rather than sequentially naming variables `v0`, `v1`, etc.
 - **Proofs**: Write out what the intermediate games are intended to be before creating the reductions that hop between games. Use comments at the top of the file to describe: the main result, the high-level proof idea, and descriptions of the sequence of games. For each reduction or intermediate game, add a comment explaining its main idea.
 - **Scope discipline**: Do exactly what is asked and nothing more. If asked to add an intermediate game, add it — do not also think ahead about what reductions will be needed or comment on upcoming proof steps. Work on reductions only when explicitly asked to.
-- **MCP**: Read `CLAUDE_MCP.md` at the start of any session involving ProofFrog proof work. It contains the full MCP tool usage guide, including how to write intermediate games, reductions, and diagnose failing steps. A MCP server exists to allow Claude to interact with the ProofFrog engine to check if code parses and type checks, and see which steps of a game hopping proof are valid. Key tools: `get_step_detail(proof_path, step_index)` returns the canonical form of a game step in an existing proof — read the `canonical` field, not `output` (which has mangled internal names). `get_inlined_game(proof_path, step_text)` returns the canonical form of an arbitrary game step using the proof's let:/assume: context, without the step needing to appear in the proof yet.
+- **MCP**: Read `CLAUDE_MCP.md` at the start of any session involving ProofFrog proof work. It contains the full MCP tool usage guide, including how to write intermediate games, reductions, and diagnose failing steps. A MCP server exists to allow Claude to interact with the ProofFrog engine to check if code parses and type checks, and see which steps of a game hopping proof are valid. Key tools: `get_step_detail(proof_path, step_index)` returns the canonical form of a game step in an existing proof — read the `canonical` field, not `output` (which has mangled internal names). `get_inlined_game(proof_path, step_text)` returns the canonical form of an arbitrary game step using the proof's let:/assume: context, without the step needing to appear in the proof yet. **If the MCP server is stale** (e.g. because the proof engine was modified during the session), use the equivalent CLI commands (`step-detail`, `inlined-game`, `canonicalization-trace`, `step-after-transform`) instead — they always use the currently installed engine. See the "CLI fallback" section in `CLAUDE_MCP.md`.
 - **Writing intermediate games**: To write an intermediate game that matches how a game step canonicalizes, use `get_step_detail` (if the step is already in the proof's games: list) or `get_inlined_game` (to evaluate any step text against the proof's let block). Write a `Game` definition whose body matches the returned `canonical` form. Prefer type aliases like `E.Ciphertext` and `BitString<G.lambda>` over raw sizes for readability.
 - **Engine limitations**: The ProofFrog engine is fairly limited and may have bugs. If a step where certain pieces of code should canonicalize to each other doesn't validate, pause and tell the user so they can investigate whether the engine should be fixed.
 - **Assumptions**: If the user specifies a particular set of security assumptions to use, stick to those unless stuck. It is okay to suggest or automatically add assumptions from `examples/Games/Misc`, as these are helper assumptions that hold statistically or work around engine limitations.

--- a/CLAUDE_MCP.md
+++ b/CLAUDE_MCP.md
@@ -75,13 +75,19 @@ example files.
 
 ### Prefer MCP tools over CLI
 
-When the MCP server is connected, **always use the MCP tools instead of running
-CLI commands via Bash**. The MCP tools return structured output that is easier to
-work with and avoids parsing text. Use:
+When the MCP server is connected **and the proof engine has not been modified
+during the current session**, always use the MCP tools instead of running CLI
+commands via Bash. The MCP tools return structured output that is easier to work
+with and avoids parsing text. Use:
 
 - `parse` and `check` instead of `python -m proof_frog parse/check`
 - `prove` instead of `python -m proof_frog prove`
 - `get_step_detail` instead of grepping prover output
+
+**Exception — stale MCP server**: If the proof engine or transforms have been
+modified during the session, the MCP server (a separate long-running process)
+will still use the old code. In that case, fall back to the CLI equivalents
+described in the "CLI fallback" section below.
 
 ### Writing intermediate games
 
@@ -175,6 +181,38 @@ or planning a proof.
 
 ---
 
+
+## CLI Fallback When the MCP Server Is Stale
+
+When the proof engine or canonicalization transforms are modified during a Claude
+session (e.g. fixing an engine bug), the MCP server process still runs the old
+code. Rather than writing ad-hoc Python scripts, use the CLI introspection
+commands — they always use the currently installed engine (after `pip install -e .`).
+
+The CLI commands output JSON with the same fields as the corresponding MCP tools:
+
+| CLI command | MCP equivalent | Usage |
+|-------------|---------------|-------|
+| `python -m proof_frog step-detail <proof> <step_index>` | `get_step_detail` | Canonical form of a proof step |
+| `python -m proof_frog inlined-game <proof> "<step_text>"` | `get_inlined_game` | Canonical form of an arbitrary step expression |
+| `python -m proof_frog canonicalization-trace <proof> <step_index>` | `get_canonicalization_trace` | Which transforms fired per iteration |
+| `python -m proof_frog step-after-transform <proof> <step_index> "<transform_name>"` | `get_step_after_transform` | Game AST after a specific transform |
+
+These complement the existing CLI commands (`parse`, `check`, `prove --json`,
+`describe --json`) which also accept `--json`/`-j` flags for structured output.
+
+### When to use CLI fallback
+
+1. The proof engine or transforms were edited during this session.
+2. The MCP server was not restarted after those edits.
+3. You need accurate canonical forms or transform traces that reflect the latest
+   engine code.
+
+After using the CLI fallback, re-install (`pip install -e .`) if needed, then
+parse the JSON output with `json.loads()` or pipe through `python -m json.tool`
+for readability.
+
+---
 
 ## Starting the server manually (for debugging)
 

--- a/proof_frog/proof_frog.py
+++ b/proof_frog/proof_frog.py
@@ -1,6 +1,9 @@
+# pylint: disable=duplicate-code  # CLI commands share return-dict patterns with web_server/mcp_server
 import json
-import sys
 import os
+import sys
+import tempfile
+from pathlib import Path
 
 import click
 from colorama import init
@@ -161,6 +164,97 @@ def describe(file: str, json_output: bool) -> None:
     except (ValueError, frog_parser.ParseError, FileNotFoundError) as e:
         click.echo(str(e), err=True)
         sys.exit(1)
+
+
+@cli.command("step-detail")
+@click.argument("file")
+@click.argument("step_index", type=click.INT)
+def step_detail(file: str, step_index: int) -> None:
+    """Get the canonical form of a proof step (JSON output)."""
+    # pylint: disable=import-outside-toplevel
+    from .web_server import _capture_inline
+
+    output, canonical, success, has_reduction, reduction, challenger, scheme = (
+        _capture_inline(file, step_index)
+    )
+    click.echo(
+        json.dumps(
+            {
+                "output": output,
+                "canonical": canonical,
+                "success": success,
+                "has_reduction": has_reduction,
+                "reduction": reduction,
+                "challenger": challenger,
+                "scheme": scheme,
+            }
+        )
+    )
+
+
+@cli.command("inlined-game")
+@click.argument("file")
+@click.argument("step_text")
+def inlined_game(file: str, step_text: str) -> None:
+    """Get the canonical form of a game step expression against a proof's context (JSON output)."""
+    # pylint: disable=import-outside-toplevel
+    from .web_server import _build_minimal_proof, _capture_inline
+
+    try:
+        proof_text = Path(file).read_text(encoding="utf-8")
+        minimal = _build_minimal_proof(proof_text, step_text)
+        if minimal is None:
+            click.echo(
+                json.dumps(
+                    {
+                        "output": "Could not extract theorem: block from proof file.",
+                        "canonical": "",
+                        "success": False,
+                    }
+                )
+            )
+            return
+        fd, tmp_path = tempfile.mkstemp(
+            suffix=".proof", dir=os.path.dirname(os.path.abspath(file))
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(minimal)
+            output, canonical, success, _, _, _, _ = _capture_inline(tmp_path, 0)
+        finally:
+            os.unlink(tmp_path)
+        click.echo(
+            json.dumps({"output": output, "canonical": canonical, "success": success})
+        )
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        click.echo(
+            json.dumps({"output": f"Error: {e}", "canonical": "", "success": False})
+        )
+
+
+@cli.command("canonicalization-trace")
+@click.argument("file")
+@click.argument("step_index", type=click.INT)
+def canonicalization_trace(file: str, step_index: int) -> None:
+    """Show which transforms fired per iteration for a proof step (JSON output)."""
+    # pylint: disable=import-outside-toplevel
+    from .web_server import _capture_canonicalization_trace
+
+    result = _capture_canonicalization_trace(file, step_index)
+    click.echo(json.dumps(result))
+
+
+@cli.command("step-after-transform")
+@click.argument("file")
+@click.argument("step_index", type=click.INT)
+@click.argument("transform_name")
+def step_after_transform(file: str, step_index: int, transform_name: str) -> None:
+    """Get game AST after applying transforms up to a named one (JSON output)."""
+    # pylint: disable=import-outside-toplevel
+    from .web_server import _capture_step_after_transform
+
+    result = _capture_step_after_transform(file, step_index, transform_name)
+    click.echo(json.dumps(result))
 
 
 @cli.command()


### PR DESCRIPTION
Expose the MCP server's proof introspection tools as CLI subcommands (step-detail, inlined-game, canonicalization-trace, step-after-transform) so they can be used when the MCP server is stale due to engine changes during a session. Update CLAUDE.md and CLAUDE_MCP.md with CLI fallback documentation.