### PR TITLE
Suppress spurious "changed on disk" alerts for web UI saves and watch all open files

### DIFF
--- a/proof_frog/web/editor.js
+++ b/proof_frog/web/editor.js
@@ -14,6 +14,7 @@ import { getModeForFile } from './cm-mode.js';
 import { updateGameHopsPanel } from './game-hops.js';
 import { updateWizardPanel } from './wizard.js';
 import { highlightActiveFile } from './file-tree.js';
+import { suppressFileChange } from './live-reload.js';
 
 // ── Toolbar helpers ───────────────────────────────────────────────────────────
 
@@ -286,6 +287,7 @@ export function closeTab(path) {
 export async function saveFile(path) {
   if (!path) return;
   const content = getTabContent(path);
+  suppressFileChange(path);
   const res = await apiFetch(`/api/file?path=${encodeURIComponent(path)}`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
@@ -332,6 +334,7 @@ export async function runCommand(endpoint, title) {
   if (tab) clearErrorHighlights(tab.cm);
 
   try {
+    suppressFileChange(state.activeTab);
     const data = await apiFetch(endpoint, {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/proof_frog/web/live-reload.js
+++ b/proof_frog/web/live-reload.js
@@ -5,6 +5,15 @@
 import { state, apiFetch } from './state.js';
 import { loadFileTree } from './file-tree.js';
 
+// ── Suppress file-change events for UI-initiated saves ──────────────────────
+
+const pendingSaves = new Set();
+
+export function suppressFileChange(path) {
+  pendingSaves.add(path);
+  setTimeout(() => pendingSaves.delete(path), 5000);
+}
+
 // ── Notification bar for dirty-tab conflicts ─────────────────────────────────
 
 function showReloadBar(path, name) {
@@ -80,6 +89,7 @@ export function connectSSE() {
     const { type, path } = event;
 
     if (type === "file_changed") {
+      if (pendingSaves.delete(path)) return; // UI-initiated save, ignore
       const tab = state.tabs.get(path);
       if (!tab) return; // File not open, nothing to do
       const currentContent = tab.cm.getValue();

--- a/proof_frog/web_server.py
+++ b/proof_frog/web_server.py
@@ -581,9 +581,9 @@ class _FrogFileHandler(FileSystemEventHandler):
         self._last_events: dict[str, float] = {}
         self._lock = threading.Lock()
 
-    def _should_handle(self, path_str: str) -> bool:
+    def _should_handle(self, path_str: str, *, check_extension: bool = True) -> bool:
         p = Path(path_str)
-        if p.suffix not in _WATCHED_EXTENSIONS:
+        if check_extension and p.suffix not in _WATCHED_EXTENSIONS:
             return False
         try:
             rel = p.relative_to(self._base)
@@ -606,7 +606,9 @@ class _FrogFileHandler(FileSystemEventHandler):
         self._broker.publish({"type": event_type, "path": rel})
 
     def on_modified(self, event: FileSystemEvent) -> None:
-        if not event.is_directory and self._should_handle(str(event.src_path)):
+        if not event.is_directory and self._should_handle(
+            str(event.src_path), check_extension=False
+        ):
             self._debounced_publish("file_changed", str(event.src_path))
 
     def on_created(self, event: FileSystemEvent) -> None:


### PR DESCRIPTION
The web UI's file-change detection (watchdog + SSE) was triggering the "changed on disk" alert even after saves initiated by the UI itself. Track paths being saved in a client-side set (with 5s auto-expiry) and skip the corresponding SSE event, so the alert only fires for external edits.

Also broadened watchdog file_changed monitoring to all file types so external edits to any file open in the UI are detected. File tree events (created/deleted) remain filtered to FrogLang extensions.