### PR TITLE
Add InlineSingleUseField transform and extend HoistFieldPureAlias to local variables

### DIFF
--- a/proof_frog/transforms/inlining.py
+++ b/proof_frog/transforms/inlining.py
@@ -830,11 +830,10 @@ class HoistFieldPureAliasTransformer(BlockTransformer):
                 continue
             expr = statement.value
             field_name = statement.var.name
-            # Skip if the expression is a plain variable, tuple, or literal
+            # Skip tuples, literals, and field-to-field copies
             if isinstance(
                 expr,
                 (
-                    frog_ast.Variable,
                     frog_ast.Tuple,
                     frog_ast.Integer,
                     frog_ast.Boolean,
@@ -843,8 +842,24 @@ class HoistFieldPureAliasTransformer(BlockTransformer):
                 ),
             ):
                 continue
-            # Only hoist array accesses (the pattern that causes ordering issues)
-            if not isinstance(expr, frog_ast.ArrayAccess):
+            # Allow array accesses (original pattern) and local-variable copies
+            # (scheme-inlining pattern where a local is copied to a field).
+            # Field-to-field copies are skipped to avoid changing canonical forms
+            # of games that are already matching.
+            if isinstance(expr, frog_ast.Variable):
+                if expr.name in self.fields:
+                    continue  # field = other_field: skip
+                # field = local_var: check it has a typed declaration in this block
+                has_typed_decl = any(
+                    isinstance(s, (frog_ast.Assignment, frog_ast.Sample))
+                    and s.the_type is not None
+                    and isinstance(s.var, frog_ast.Variable)
+                    and s.var.name == expr.name
+                    for s in block.statements[:i]
+                )
+                if not has_typed_decl:
+                    continue  # not a local: skip
+            elif not isinstance(expr, frog_ast.ArrayAccess):
                 continue
             # Only handle pure expressions (no function calls)
             if (
@@ -925,10 +940,18 @@ class HoistFieldPureAliasTransformer(BlockTransformer):
                 if not all_defined:
                     continue
                 # Hoist: move field assignment to before position j,
-                # replace the subexpression in position j with the field
+                # replace the subexpression in position j with the field.
+                # Re-find the match in a deep copy (ReplaceTransformer uses
+                # identity, so we need a node from the same copy).
+                new_earlier = copy.deepcopy(earlier)
+                match_in_copy = SearchVisitor(
+                    functools.partial(matches_expr, expr)
+                ).visit(new_earlier)
+                if match_in_copy is None:
+                    continue
                 new_earlier = ReplaceTransformer(
-                    match, frog_ast.Variable(field_name)
-                ).transform(copy.deepcopy(earlier))
+                    match_in_copy, frog_ast.Variable(field_name)
+                ).transform(new_earlier)
                 new_stmts = (
                     list(block.statements[:j])
                     + [copy.deepcopy(statement)]
@@ -945,3 +968,233 @@ class HoistFieldPureAlias(TransformPass):
 
     def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
         return HoistFieldPureAliasTransformer().transform(game)
+
+
+class InlineSingleUseFieldTransformer(BlockTransformer):
+    """Inlines a field assignment ``fieldA = expr`` when fieldA is used exactly
+    once across all methods and no free variable in expr is modified between the
+    definition and the single use site.
+
+    After inlining, the field declaration is removed from the game.
+
+    This complements ``InlineSingleUseVariableTransformer`` which only handles
+    typed local declarations (``Type v = expr``).  This transform handles
+    untyped field assignments where the field becomes a single-use alias after
+    other transforms (e.g. ``IfConditionAliasSubstitution``) eliminate uses.
+
+    Example::
+
+        Game Test() {
+            Int field4;
+            Int ct_PQ;
+            Void Initialize() {
+                ct_PQ = 42;
+                field4 = ct_PQ;
+            }
+        }
+
+    becomes::
+
+        Game Test() {
+            Int field4;
+            Void Initialize() {
+                field4 = 42;
+            }
+        }
+    """
+
+    def __init__(self) -> None:
+        self.field_names: list[str] = []
+
+    def _transform_block_wrapper(self, block: frog_ast.Block) -> frog_ast.Block:
+        return block  # All work done in transform_game
+
+    def transform_game(self, game: frog_ast.Game) -> frog_ast.Game:
+        self.field_names = [field.name for field in game.fields]
+        changed = True
+        result = game
+        while changed:
+            changed = False
+            # Try inlining declared fields
+            for field_name in list(self.field_names):
+                new_game = self._try_inline_field(result, field_name)
+                if new_game is not None:
+                    result = new_game
+                    self.field_names = [f.name for f in result.fields]
+                    changed = True
+                    break
+            if changed:
+                continue
+            # Try inlining orphaned untyped variables: variables that have
+            # untyped assignments but are NOT in the fields list (happens when
+            # RemoveUnnecessaryFields removes a field declaration but leaves
+            # the assignment statement).
+            for orphan in self._find_orphaned_vars(result):
+                new_game = self._try_inline_field(result, orphan)
+                if new_game is not None:
+                    result = new_game
+                    self.field_names = [f.name for f in result.fields]
+                    changed = True
+                    break
+        return result
+
+    def _find_orphaned_vars(self, game: frog_ast.Game) -> list[str]:
+        """Find variables with untyped assignments that are not in the fields list."""
+        orphans: list[str] = []
+        for method in game.methods:
+            for stmt in method.block.statements:
+                if (
+                    isinstance(stmt, frog_ast.Assignment)
+                    and stmt.the_type is None
+                    and isinstance(stmt.var, frog_ast.Variable)
+                    and stmt.var.name not in self.field_names
+                    and stmt.var.name not in orphans
+                ):
+                    orphans.append(stmt.var.name)
+        return orphans
+
+    def _try_inline_field(
+        self, game: frog_ast.Game, field_name: str
+    ) -> frog_ast.Game | None:
+        """Try to inline a single field. Returns new game or None."""
+
+        # 1. Find the single assignment to this field across all methods
+        assign_count = 0
+        assign_method_idx = -1
+        assign_stmt_idx = -1
+        assign_expr: frog_ast.Expression | None = None
+
+        for mi, method in enumerate(game.methods):
+            for si, stmt in enumerate(method.block.statements):
+                if (
+                    isinstance(stmt, frog_ast.Assignment)
+                    and stmt.the_type is None
+                    and isinstance(stmt.var, frog_ast.Variable)
+                    and stmt.var.name == field_name
+                ):
+                    assign_count += 1
+                    assign_method_idx = mi
+                    assign_stmt_idx = si
+                    assign_expr = stmt.value
+
+        if assign_count != 1 or assign_expr is None:
+            return None
+
+        # 2. Count total uses of field_name across the entire game
+        def uses_field(node: frog_ast.ASTNode) -> bool:
+            return isinstance(node, frog_ast.Variable) and node.name == field_name
+
+        total_uses = 0
+        count_game = copy.deepcopy(game)
+        # Don't count the definition itself — replace the LHS variable name
+        # so uses_field won't match it.
+        count_def = count_game.methods[assign_method_idx].block.statements[
+            assign_stmt_idx
+        ]
+        assert isinstance(count_def, frog_ast.Assignment)
+        count_def.var = frog_ast.Variable("__placeholder__")
+
+        while True:
+            found = SearchVisitor(uses_field).visit(count_game)
+            if found is None:
+                break
+            total_uses += 1
+            count_game = ReplaceTransformer(
+                found, frog_ast.Variable(field_name + "__counted__")
+            ).transform(count_game)
+
+        if total_uses == 0:
+            return None
+
+        # For multi-use fields, only inline if the expression is pure
+        # (no function calls), so duplicating it is safe.
+        is_pure = (
+            SearchVisitor(lambda n: isinstance(n, frog_ast.FuncCall)).visit(assign_expr)
+            is None
+        )
+        if total_uses > 1 and not is_pure:
+            return None
+
+        # 3. All uses must be in the same method as the definition —
+        # cross-method inlining is wrong because field values are stored once.
+        all_same_method = True
+        for mi, method in enumerate(game.methods):
+            if mi == assign_method_idx:
+                continue
+            for si, stmt in enumerate(method.block.statements):
+                if SearchVisitor(uses_field).visit(stmt) is not None:
+                    all_same_method = False
+                    break
+            if not all_same_method:
+                break
+
+        if not all_same_method:
+            return None
+
+        # 4. Check that no free variable in expr is modified between def and last use
+        last_use_idx = -1
+        for si, stmt in enumerate(game.methods[assign_method_idx].block.statements):
+            if si == assign_stmt_idx:
+                continue
+            if SearchVisitor(uses_field).visit(stmt) is not None:
+                last_use_idx = si
+        if last_use_idx >= 0:
+            free_vars = VariableCollectionVisitor().visit(copy.deepcopy(assign_expr))
+            intermediate_stmts = game.methods[assign_method_idx].block.statements[
+                assign_stmt_idx + 1 : last_use_idx
+            ]
+            intermediate = frog_ast.Block(list(intermediate_stmts))
+
+            def is_written_to(name: str, node: frog_ast.ASTNode) -> bool:
+                return (
+                    isinstance(node, (frog_ast.Sample, frog_ast.Assignment))
+                    and isinstance(node.var, frog_ast.Variable)
+                    and node.var.name == name
+                )
+
+            if any(
+                SearchVisitor(functools.partial(is_written_to, fv.name)).visit(
+                    intermediate
+                )
+                is not None
+                for fv in free_vars
+            ):
+                return None
+
+        # 5. Perform the inlining — replace ALL occurrences in the method
+        new_game = copy.deepcopy(game)
+
+        method = new_game.methods[assign_method_idx]
+        # Replace in each statement except the definition
+        new_stmts = list(method.block.statements)
+        for si, stmt in enumerate(new_stmts):
+            if si == assign_stmt_idx:
+                continue
+            while True:
+                field_node = SearchVisitor(uses_field).visit(stmt)
+                if field_node is None:
+                    break
+                stmt = ReplaceTransformer(
+                    field_node, copy.deepcopy(assign_expr)
+                ).transform(stmt)
+            new_stmts[si] = stmt
+        method.block = frog_ast.Block(new_stmts)
+
+        # Remove the definition statement
+        method = new_game.methods[assign_method_idx]
+        method.block = frog_ast.Block(
+            list(method.block.statements[:assign_stmt_idx])
+            + list(method.block.statements[assign_stmt_idx + 1 :])
+        )
+
+        # Remove the field declaration
+        new_game.fields = [f for f in new_game.fields if f.name != field_name]
+
+        return new_game
+
+
+class InlineSingleUseField(TransformPass):
+    name = "Inline Single-Use Field"
+
+    def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
+        return InlineSingleUseFieldTransformer().transform(game)

--- a/proof_frog/transforms/pipelines.py
+++ b/proof_frog/transforms/pipelines.py
@@ -24,6 +24,7 @@ from .random_functions import (
 from .inlining import (
     RedundantCopy,
     InlineSingleUseVariable,
+    InlineSingleUseField,
     ForwardExpressionAlias,
     HoistFieldPureAlias,
     InlineMultiUsePureExpression,
@@ -92,6 +93,7 @@ CORE_PIPELINE: list[TransformPass] = [
     IfConditionAliasSubstitution(),
     RedundantConditionalReturn(),
     BranchElimination(),
+    InlineSingleUseField(),
     RemoveUnnecessaryFields(),
     CollapseAssignment(),
     SimplifyReturn(),

--- a/tests/unit/transforms/test_hoist_field_pure_alias.py
+++ b/tests/unit/transforms/test_hoist_field_pure_alias.py
@@ -1,0 +1,113 @@
+import pytest
+from proof_frog import frog_parser
+from proof_frog.transforms.inlining import HoistFieldPureAliasTransformer
+
+
+def _transform_and_compare(source: str, expected: str) -> None:
+    game = frog_parser.parse_game(source)
+    expected_ast = frog_parser.parse_game(expected)
+    result = HoistFieldPureAliasTransformer().transform(game)
+    assert result == expected_ast, f"\nGot:\n{result}\nExpected:\n{expected_ast}"
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        # Variable hoisting: field = v where v appears in earlier statement's expression
+        (
+            """
+            Game Test() {
+                Int field2;
+                Int field7;
+                Void Initialize() {
+                    [Int, Int] pair = K.evaluate(1);
+                    Int v4 = pair[0];
+                    field2 = v4 + 1;
+                    field7 = v4;
+                }
+            }
+            """,
+            """
+            Game Test() {
+                Int field2;
+                Int field7;
+                Void Initialize() {
+                    [Int, Int] pair = K.evaluate(1);
+                    Int v4 = pair[0];
+                    field7 = v4;
+                    field2 = field7 + 1;
+                }
+            }
+            """,
+        ),
+        # Variable not used in earlier statement — no hoisting
+        (
+            """
+            Game Test() {
+                Int field7;
+                Int field2;
+                Void Initialize() {
+                    [Int, Int] pair = K.evaluate(1);
+                    Int v4 = pair[0];
+                    field2 = 42;
+                    field7 = v4;
+                }
+            }
+            """,
+            """
+            Game Test() {
+                Int field7;
+                Int field2;
+                Void Initialize() {
+                    [Int, Int] pair = K.evaluate(1);
+                    Int v4 = pair[0];
+                    field2 = 42;
+                    field7 = v4;
+                }
+            }
+            """,
+        ),
+        # Variable only used in its own definition — no hoisting
+        (
+            """
+            Game Test() {
+                Int field7;
+                Void Initialize() {
+                    [Int, Int] pair = K.evaluate(1);
+                    Int v4 = pair[0];
+                    field7 = v4;
+                }
+            }
+            """,
+            """
+            Game Test() {
+                Int field7;
+                Void Initialize() {
+                    [Int, Int] pair = K.evaluate(1);
+                    Int v4 = pair[0];
+                    field7 = v4;
+                }
+            }
+            """,
+        ),
+    ],
+)
+def test_hoist_field_pure_alias(source: str, expected: str) -> None:
+    _transform_and_compare(source, expected)
+
+
+def test_field_to_field_copy_not_hoisted() -> None:
+    """field = other_field should NOT be hoisted (only field = local_var)."""
+    source = """
+    Game Test() {
+        Int field1;
+        Int field2;
+        Int field3;
+        Void Initialize() {
+            field1 = 42;
+            field3 = field1 + 1;
+            field2 = field1;
+        }
+    }
+    """
+    _transform_and_compare(source, source)

--- a/tests/unit/transforms/test_inline_single_use_field.py
+++ b/tests/unit/transforms/test_inline_single_use_field.py
@@ -1,0 +1,387 @@
+import pytest
+from proof_frog import frog_parser
+from proof_frog.transforms.inlining import InlineSingleUseFieldTransformer
+
+
+def _transform_and_compare(source: str, expected: str) -> None:
+    game = frog_parser.parse_game(source)
+    expected_ast = frog_parser.parse_game(expected)
+    result = InlineSingleUseFieldTransformer().transform(game)
+    assert result == expected_ast, f"\nGot:\n{result}\nExpected:\n{expected_ast}"
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        # Basic: field ct_PQ assigned once, used once in another field assignment
+        (
+            """
+            Game Test() {
+                Int field4;
+                Int ct_PQ;
+                Void Initialize() {
+                    ct_PQ = 42;
+                    field4 = ct_PQ;
+                }
+                Int PK() {
+                    return field4;
+                }
+                Int CT() {
+                    return field4;
+                }
+            }
+            """,
+            """
+            Game Test() {
+                Int field4;
+                Void Initialize() {
+                    field4 = 42;
+                }
+                Int PK() {
+                    return field4;
+                }
+                Int CT() {
+                    return field4;
+                }
+            }
+            """,
+        ),
+        # Field used in expression (not just plain copy)
+        (
+            """
+            Game Test() {
+                Int field3;
+                Int ct_PQ;
+                Void Initialize() {
+                    ct_PQ = 42;
+                    field3 = ct_PQ + 1;
+                }
+                Int PK() {
+                    return field3;
+                }
+                Int CT() {
+                    return field3;
+                }
+            }
+            """,
+            """
+            Game Test() {
+                Int field3;
+                Void Initialize() {
+                    field3 = 42 + 1;
+                }
+                Int PK() {
+                    return field3;
+                }
+                Int CT() {
+                    return field3;
+                }
+            }
+            """,
+        ),
+        # Pure field used in two places within same method — SHOULD be inlined
+        (
+            """
+            Game Test() {
+                Int field3;
+                Int field4;
+                Int ct_PQ;
+                Void Initialize() {
+                    ct_PQ = 42;
+                    field3 = ct_PQ + 1;
+                    field4 = ct_PQ;
+                }
+                Int PK() {
+                    return field3 + field4;
+                }
+                Int CT() {
+                    return field3 + field4;
+                }
+            }
+            """,
+            """
+            Game Test() {
+                Int field3;
+                Int field4;
+                Void Initialize() {
+                    field3 = 42 + 1;
+                    field4 = 42;
+                }
+                Int PK() {
+                    return field3 + field4;
+                }
+                Int CT() {
+                    return field3 + field4;
+                }
+            }
+            """,
+        ),
+        # Field used across methods — should NOT be inlined
+        (
+            """
+            Game Test() {
+                Int field4;
+                Int ct_PQ;
+                Void Initialize() {
+                    ct_PQ = 42;
+                    field4 = ct_PQ;
+                }
+                Int PK() {
+                    return ct_PQ + field4;
+                }
+                Int CT() {
+                    return field4;
+                }
+            }
+            """,
+            """
+            Game Test() {
+                Int field4;
+                Int ct_PQ;
+                Void Initialize() {
+                    ct_PQ = 42;
+                    field4 = ct_PQ;
+                }
+                Int PK() {
+                    return ct_PQ + field4;
+                }
+                Int CT() {
+                    return field4;
+                }
+            }
+            """,
+        ),
+        # Field assigned multiple times — should NOT be inlined
+        (
+            """
+            Game Test() {
+                Int field4;
+                Int ct_PQ;
+                Void Initialize() {
+                    ct_PQ = 1;
+                    ct_PQ = 2;
+                    field4 = ct_PQ;
+                }
+                Int PK() {
+                    return field4;
+                }
+                Int CT() {
+                    return field4;
+                }
+            }
+            """,
+            """
+            Game Test() {
+                Int field4;
+                Int ct_PQ;
+                Void Initialize() {
+                    ct_PQ = 1;
+                    ct_PQ = 2;
+                    field4 = ct_PQ;
+                }
+                Int PK() {
+                    return field4;
+                }
+                Int CT() {
+                    return field4;
+                }
+            }
+            """,
+        ),
+        # Expression with function call — still inlinable if single use
+        (
+            """
+            Game Test() {
+                Int field4;
+                Int ct_PQ;
+                Void Initialize() {
+                    ct_PQ = F.evaluate(1);
+                    field4 = ct_PQ;
+                }
+                Int PK() {
+                    return field4;
+                }
+                Int CT() {
+                    return field4;
+                }
+            }
+            """,
+            """
+            Game Test() {
+                Int field4;
+                Void Initialize() {
+                    field4 = F.evaluate(1);
+                }
+                Int PK() {
+                    return field4;
+                }
+                Int CT() {
+                    return field4;
+                }
+            }
+            """,
+        ),
+        # Free variable modified between def and use — should NOT be inlined
+        (
+            """
+            Game Test() {
+                Int field3;
+                Int field4;
+                Int ct_PQ;
+                Void Initialize() {
+                    ct_PQ = field3 + 1;
+                    field3 = 99;
+                    field4 = ct_PQ;
+                }
+                Int PK() {
+                    return field4 + field3;
+                }
+                Int CT() {
+                    return field4 + field3;
+                }
+            }
+            """,
+            """
+            Game Test() {
+                Int field3;
+                Int field4;
+                Int ct_PQ;
+                Void Initialize() {
+                    ct_PQ = field3 + 1;
+                    field3 = 99;
+                    field4 = ct_PQ;
+                }
+                Int PK() {
+                    return field4 + field3;
+                }
+                Int CT() {
+                    return field4 + field3;
+                }
+            }
+            """,
+        ),
+    ],
+)
+def test_inline_single_use_field(source: str, expected: str) -> None:
+    _transform_and_compare(source, expected)
+
+
+@pytest.mark.parametrize(
+    "source,expected",
+    [
+        # Pure expression (tuple index) used twice in same method — should be inlined
+        (
+            """
+            Game Test() {
+                Int field3;
+                Int field4;
+                Int ct_PQ;
+                Void Initialize() {
+                    ct_PQ = 42;
+                    field3 = ct_PQ + 1;
+                    field4 = ct_PQ;
+                }
+                Int PK() {
+                    return field3 + field4;
+                }
+                Int CT() {
+                    return field3 + field4;
+                }
+            }
+            """,
+            """
+            Game Test() {
+                Int field3;
+                Int field4;
+                Void Initialize() {
+                    field3 = 42 + 1;
+                    field4 = 42;
+                }
+                Int PK() {
+                    return field3 + field4;
+                }
+                Int CT() {
+                    return field3 + field4;
+                }
+            }
+            """,
+        ),
+        # Non-pure expression (function call) used twice — should NOT be inlined
+        (
+            """
+            Game Test() {
+                Int field3;
+                Int field4;
+                Int ct_PQ;
+                Void Initialize() {
+                    ct_PQ = F.evaluate(1);
+                    field3 = ct_PQ + 1;
+                    field4 = ct_PQ;
+                }
+                Int PK() {
+                    return field3 + field4;
+                }
+                Int CT() {
+                    return field3 + field4;
+                }
+            }
+            """,
+            """
+            Game Test() {
+                Int field3;
+                Int field4;
+                Int ct_PQ;
+                Void Initialize() {
+                    ct_PQ = F.evaluate(1);
+                    field3 = ct_PQ + 1;
+                    field4 = ct_PQ;
+                }
+                Int PK() {
+                    return field3 + field4;
+                }
+                Int CT() {
+                    return field3 + field4;
+                }
+            }
+            """,
+        ),
+    ],
+)
+def test_inline_multi_use_pure_field(source: str, expected: str) -> None:
+    _transform_and_compare(source, expected)
+
+
+def test_inline_orphaned_untyped_variable() -> None:
+    """An untyped assignment to a variable NOT in the fields list should be
+    inlined — this happens when RemoveUnnecessaryFields removes a field
+    declaration but leaves the assignment statement."""
+    source = """
+    Game Test() {
+        Int field4;
+        Void Initialize() {
+            ct_PQ = K.evaluate(1);
+            field4 = ct_PQ;
+        }
+        Int PK() {
+            return field4;
+        }
+        Int CT() {
+            return field4;
+        }
+    }
+    """
+    expected = """
+    Game Test() {
+        Int field4;
+        Void Initialize() {
+            field4 = K.evaluate(1);
+        }
+        Int PK() {
+            return field4;
+        }
+        Int CT() {
+            return field4;
+        }
+    }
+    """
+    _transform_and_compare(source, expected)


### PR DESCRIPTION
Adds a new canonicalization transform that inlines field assignments used exactly once (or multiple times if pure) within the same method, removing the intermediate field. Also extends HoistFieldPureAlias to handle local-variable-to-field copies and fixes a deep-copy bug in the ReplaceTransformer usage.