### PR TITLE
Add multi-level verbosity to prove command and web UI

### DIFF
--- a/proof_frog/proof_engine.py
+++ b/proof_frog/proof_engine.py
@@ -5,7 +5,7 @@ import difflib
 import functools
 import shutil
 import warnings
-from enum import Enum
+from enum import Enum, IntEnum
 from collections import namedtuple
 from typing import TypeAlias, Tuple, Dict, Optional, TypeVar, Union
 import z3
@@ -181,14 +181,27 @@ class _AllTrueTransformer(visitors.Transformer):
         )
 
 
+class Verbosity(IntEnum):
+    """Verbosity levels for proof engine output."""
+
+    QUIET = 0  # Default: summary table only
+    NORMAL = 1  # Show intermediate games (step headers, game forms)
+    VERBOSE = 2  # Show every transform applied
+
+
 class ProofEngine:
-    def __init__(self, verbose: bool, no_diagnose: bool = False) -> None:
+    def __init__(
+        self, verbose: bool | Verbosity = False, no_diagnose: bool = False
+    ) -> None:
         self.definition_namespace: frog_ast.Namespace = {}
         self.proof_namespace: frog_ast.Namespace = {}
         self.proof_let_types: visitors.NameTypeMap = visitors.NameTypeMap()
         self.subsets_pairs: list[tuple[frog_ast.Type, frog_ast.Type]] = []
 
-        self.verbose = verbose
+        if isinstance(verbose, bool):
+            self.verbosity = Verbosity.VERBOSE if verbose else Verbosity.QUIET
+        else:
+            self.verbosity = verbose
         self.no_diagnose = no_diagnose
         self.step_assumptions: list[ProcessedAssumption] = []
         self.hop_results: list[HopResult] = []
@@ -456,9 +469,9 @@ class ProofEngine:
             diag = equiv_result.diagnosis
             indent = "  " + " " * (len(str(self._total_steps)) * 2 + 9)
             print(f"{indent}{Fore.YELLOW}{diag.summary}{Fore.RESET}")
-        if self.verbose and equiv_result.failure_detail:
+        if self.verbosity >= Verbosity.VERBOSE and equiv_result.failure_detail:
             _print_failure_detail(equiv_result.failure_detail)
-        if self.verbose and equiv_result.diagnosis is not None:
+        if self.verbosity >= Verbosity.VERBOSE and equiv_result.diagnosis is not None:
             diag = equiv_result.diagnosis
             if diag.explanations:
                 print("    Near-misses:")
@@ -523,7 +536,7 @@ class ProofEngine:
             next_step = steps[i]
             self._current_step += 1
 
-            if self.verbose:
+            if self.verbosity >= Verbosity.NORMAL:
                 print(f"===STEP {step_num}===")
 
             current_game_ast: frog_ast.Game
@@ -537,7 +550,7 @@ class ProofEngine:
                 ):
                     current_desc = str(current_step)
                     next_desc = str(next_step)
-                    if self.verbose:
+                    if self.verbosity >= Verbosity.NORMAL:
                         print(f"Current: {current_desc}")
                         print(f"Hop To: {next_desc}\n")
                         print("Valid by assumption")
@@ -602,7 +615,7 @@ class ProofEngine:
             current_desc = str(current_step)
             next_desc = str(next_step)
 
-            if self.verbose:
+            if self.verbosity >= Verbosity.NORMAL:
                 print(f"Current: {current_desc}")
                 print(f"Hop To: {next_desc}\n")
 
@@ -669,7 +682,7 @@ class ProofEngine:
                 self._current_step += 1
                 rollover_current_desc = str(last_step)
                 rollover_next_desc = str(first_step)
-                if self.verbose:
+                if self.verbosity >= Verbosity.NORMAL:
                     print("CHECKING INDUCTION ROLLOVER")
                     print(f"Current: {rollover_current_desc}")
                     print(f"Hop To: {rollover_next_desc}\n")
@@ -783,7 +796,7 @@ class ProofEngine:
             which = WhichGame.CURRENT if index == 0 else WhichGame.NEXT
             ctx.near_misses = []  # Reset for each game
 
-            if self.verbose:
+            if self.verbosity >= Verbosity.VERBOSE:
                 label = "CURRENT" if index == 0 else "NEXT"
                 print(f"SIMPLIFYING {label} GAME")
                 print(game)
@@ -791,7 +804,12 @@ class ProofEngine:
             pipeline = list(CORE_PIPELINE) + [
                 ApplyAssumptions(self.step_assumptions, which, self.proof_let_types)
             ]
-            game = run_pipeline(game, pipeline, ctx, verbose=self.verbose)
+            game = run_pipeline(
+                game,
+                pipeline,
+                ctx,
+                verbose=self.verbosity >= Verbosity.VERBOSE,
+            )
             game = run_standardization(game, STANDARDIZATION_PIPELINE, ctx)
 
             if index == 0:
@@ -801,14 +819,14 @@ class ProofEngine:
                 next_game_ast = game
                 next_near_misses = deduplicate_near_misses(ctx.near_misses)
 
-        if self.verbose:
+        if self.verbosity >= Verbosity.NORMAL:
             print("CURRENT")
             print(current_game_ast)
             print("NEXT")
             print(next_game_ast)
 
         if current_game_ast == next_game_ast:
-            if self.verbose:
+            if self.verbosity >= Verbosity.NORMAL:
                 print("Inline Success!")
             return EquivalenceResult(valid=True)
 
@@ -902,7 +920,7 @@ class ProofEngine:
                             f"{condition} vs {if_next.conditions[i]}"
                         ),
                     )
-        if self.verbose:
+        if self.verbosity >= Verbosity.NORMAL:
             print("Inline Success!")
         return EquivalenceResult(valid=True)
 

--- a/proof_frog/proof_frog.py
+++ b/proof_frog/proof_frog.py
@@ -75,14 +75,19 @@ def check(file: str, json_output: bool) -> None:
 
 @cli.command()
 @click.argument("file")
-@click.option("-v", "--verbose", is_flag=True, help="Enable verbose output.")
+@click.option(
+    "-v",
+    "--verbose",
+    count=True,
+    help="Increase verbosity (-v for games, -vv for transforms).",
+)
 @click.option("--json", "-j", "json_output", is_flag=True, help="Output JSON.")
 @click.option(
     "--no-diagnose",
     is_flag=True,
     help="Suppress diagnostic analysis on failure (summary only).",
 )
-def prove(file: str, verbose: bool, json_output: bool, no_diagnose: bool) -> None:
+def prove(file: str, verbose: int, json_output: bool, no_diagnose: bool) -> None:
     """Run proof verification on a .proof file."""
     if json_output:
         # pylint: disable=import-outside-toplevel
@@ -97,7 +102,8 @@ def prove(file: str, verbose: bool, json_output: bool, no_diagnose: bool) -> Non
             )
         )
         return
-    engine = proof_engine.ProofEngine(verbose, no_diagnose=no_diagnose)
+    verbosity = proof_engine.Verbosity(min(verbose, 2))
+    engine = proof_engine.ProofEngine(verbosity, no_diagnose=no_diagnose)
     proof_file: frog_ast.ProofFile
     try:
         proof_file = frog_parser.parse_proof_file(file)

--- a/proof_frog/web/editor.js
+++ b/proof_frog/web/editor.js
@@ -6,7 +6,7 @@
 import {
   state,
   tabsEl, tabsEmpty, editorsContainer, welcome,
-  btnSave, btnParse, btnProve,
+  btnSave, btnParse, btnProve, proveVerbosity,
   outputPane, outputStatus, outputTitle, outputPre,
   apiFetch, getCmTheme,
 } from './state.js';
@@ -26,6 +26,7 @@ export function updateToolbar() {
   const isProof = hasTab && !isVirtual && state.activeTab.endsWith(".proof");
   btnProve.style.display = isProof ? "" : "none";
   btnProve.disabled = !isProof;
+  proveVerbosity.style.display = isProof ? "" : "none";
 }
 
 export function setRunning(running) {
@@ -335,10 +336,14 @@ export async function runCommand(endpoint, title) {
 
   try {
     suppressFileChange(state.activeTab);
+    const payload = { path: state.activeTab, content };
+    if (endpoint === "/api/prove") {
+      payload.verbosity = parseInt(proveVerbosity.value, 10);
+    }
     const data = await apiFetch(endpoint, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ path: state.activeTab, content }),
+      body: JSON.stringify(payload),
     });
 
     // Update saved state (auto-save happened server-side)

--- a/proof_frog/web/index.html
+++ b/proof_frog/web/index.html
@@ -23,6 +23,11 @@
     <button id="btn-save" title="Save (Ctrl+S)" disabled>Save</button>
     <button id="btn-parse" class="primary" title="Parse current file" disabled>Parse</button>
     <button id="btn-prove" class="primary" title="Run proof" disabled style="display:none">Run Proof</button>
+    <select id="prove-verbosity" title="Verbosity level" style="display:none">
+      <option value="0">Quiet</option>
+      <option value="1">Verbose</option>
+      <option value="2">Very Verbose</option>
+    </select>
 <span class="spacer"></span>
     <span class="dir-label" id="dir-label"></span>
     <button id="btn-theme" title="Toggle light/dark mode">Dark</button>

--- a/proof_frog/web/state.js
+++ b/proof_frog/web/state.js
@@ -21,6 +21,7 @@ export const welcome           = document.getElementById("welcome");
 export const btnSave           = document.getElementById("btn-save");
 export const btnParse          = document.getElementById("btn-parse");
 export const btnProve          = document.getElementById("btn-prove");
+export const proveVerbosity    = document.getElementById("prove-verbosity");
 export const btnTheme          = document.getElementById("btn-theme");
 export const dirLabel          = document.getElementById("dir-label");
 export const outputPane        = document.getElementById("output-pane");

--- a/proof_frog/web/style.css
+++ b/proof_frog/web/style.css
@@ -61,6 +61,10 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
 #toolbar button:disabled { opacity: 0.4; cursor: default; }
 #toolbar button.primary { border-color: var(--accent2); color: var(--accent2); }
 #toolbar button.running { opacity: 0.6; }
+#toolbar select {
+  padding: 3px 6px; border: 1px solid var(--border); border-radius: 3px;
+  background: var(--bg2); color: var(--text); font-size: 12px;
+}
 #toolbar .spacer { flex: 1; }
 #toolbar .dir-label { color: var(--text-dim); font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 300px; }
 

--- a/proof_frog/web_server.py
+++ b/proof_frog/web_server.py
@@ -416,10 +416,12 @@ def _capture_step_after_transform(
 
 
 def _capture_prove(
-    file_path: str, allowed_root: str | None = None
+    file_path: str,
+    allowed_root: str | None = None,
+    verbosity: proof_engine.Verbosity = proof_engine.Verbosity.QUIET,
 ) -> tuple[str, bool, list[dict[str, object]], bool, int | None, int | None]:
     buf = io.StringIO()
-    engine = proof_engine.ProofEngine(False)
+    engine = proof_engine.ProofEngine(verbosity)
     proof_succeeded = False
     has_induction = False
     try:
@@ -753,12 +755,18 @@ def create_app(directory: str, *, watch: bool = True) -> tuple[Flask, Any]:
             return jsonify({"error": "No data"}), 400
         rel_path = data.get("path", "")
         content = data.get("content", "")
+        verbosity_val = data.get("verbosity", 0)
+        verbosity = proof_engine.Verbosity(
+            max(0, min(int(verbosity_val), 2))
+            if isinstance(verbosity_val, (int, float))
+            else 0
+        )
         abs_path = _safe_path(directory, rel_path)
         if abs_path is None:
             return jsonify({"error": "Invalid path"}), 403
         abs_path.write_text(content, encoding="utf-8")
         output, success, hop_results, has_induction, error_line, error_column = (
-            _capture_prove(str(abs_path), allowed_root=directory)
+            _capture_prove(str(abs_path), allowed_root=directory, verbosity=verbosity)
         )
         prove_resp: dict[str, object] = {
             "output": output,


### PR DESCRIPTION
Replace the boolean --verbose flag with a counted -v option:
- No flag: summary table only (unchanged default)
- -v: show intermediate games (step headers, canonical forms)
- -vv: show every transform applied (previous -v behavior)

Add verbosity dropdown to the web UI toolbar, passed to the /api/prove endpoint as an optional "verbosity" field.