### PR TITLE
Reject schemes as game file parameters in the typechecker

### DIFF
--- a/proof_frog/semantic_analysis.py
+++ b/proof_frog/semantic_analysis.py
@@ -433,6 +433,18 @@ class NameResolutionVisitor(VariableTypeVisitor):
                         self.file_name,
                     )
 
+        for param in game_file.games[0].parameters:
+            if isinstance(param.type, frog_ast.Variable):
+                imported = self.import_namespace.get(param.type.name)
+                if isinstance(imported, frog_ast.Scheme):
+                    print_error(
+                        param,
+                        f"Game parameter '{param.name}' has type"
+                        f" '{param.type.name}' which is a scheme;"
+                        f" game parameters must be primitives",
+                        self.file_name,
+                    )
+
         if game_file.games[0].name == game_file.games[1].name:
             print_error(
                 game_file, "Cannot have two games with the same name", self.file_name

--- a/tests/unit/typechecking/test_semantic_errors.py
+++ b/tests/unit/typechecking/test_semantic_errors.py
@@ -206,6 +206,48 @@ class TestMethodNotFoundSuggestions:
         assert "2" in stderr
 
 
+    def test_scheme_as_game_parameter_rejected(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Game parameters must be primitives, not schemes."""
+        prim = tmp_path / "MyHash.primitive"
+        prim.write_text(
+            "Primitive MyHash(Int n) {\n"
+            "    Int n = n;\n"
+            "    BitString<n> f(BitString x);\n"
+            "}\n"
+        )
+        scheme = tmp_path / "MyScheme.scheme"
+        scheme.write_text(
+            "import 'MyHash.primitive';\n\n"
+            "Scheme MyScheme(MyHash h) extends MyHash {\n"
+            "    Int n = h.n;\n"
+            "    BitString<n> f(BitString x) {\n"
+            "        return h.f(x);\n"
+            "    }\n"
+            "}\n"
+        )
+        source = (
+            "import 'MyHash.primitive';\n"
+            "import 'MyScheme.scheme';\n\n"
+            "Game Real(MyHash h, MyScheme sch) {\n"
+            "    Bool Query() {\n"
+            "        return true;\n"
+            "    }\n"
+            "}\n"
+            "Game Random(MyHash h, MyScheme sch) {\n"
+            "    Bool Query() {\n"
+            "        return true;\n"
+            "    }\n"
+            "}\n"
+            "export as Test;\n"
+        )
+        stderr = _check_error_stderr(tmp_path, capsys, source, ext=".game")
+        assert "which is a scheme" in stderr
+        assert "'sch'" in stderr
+        assert "'MyScheme'" in stderr
+
+
 class TestImportPathSuggestions:
     def test_typo_in_import_filename(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
Security definitions (.game files) should only accept primitives and basic types as parameters. The typechecker now errors when a game parameter type resolves to a scheme in the import namespace.