### PR TITLE
Add DistinctConstRFToUniform with length-carrying BinaryNum refactor

### DIFF
--- a/proof_frog/frog_ast.py
+++ b/proof_frog/frog_ast.py
@@ -631,12 +631,24 @@ class NoneExpression(Expression, Type):
 
 
 class BinaryNum(Expression):
-    def __init__(self, num: int):
+    """A binary literal written as ``0bXYZ``.
+
+    Carries both the integer value and the explicit bit length.  The length
+    is the number of ``0``/``1`` digits after ``0b`` in the source, so
+    ``0b0`` has length 1, ``0b00`` has length 2, ``0b101`` has length 3.
+    Two ``BinaryNum`` nodes with the same ``num`` but different ``length``
+    represent different bitstrings (they live in different ``BitString<n>``
+    types).
+    """
+
+    def __init__(self, num: int, length: int):
         super().__init__()
         self.num = num
+        self.length = length
 
     def __str__(self) -> str:
-        return bin(self.num)
+        # Render with leading zeros to preserve the explicit length.
+        return "0b" + format(self.num, f"0{self.length}b")
 
 
 class BitStringLiteral(Expression):

--- a/proof_frog/frog_parser.py
+++ b/proof_frog/frog_parser.py
@@ -909,7 +909,10 @@ class _SharedAST(PrimitiveVisitor, SchemeVisitor, GameVisitor, ProofVisitor):  #
         if ctx.INT():
             return frog_ast.Integer(int(ctx.INT().getText()))
         if ctx.BINARYNUM():
-            return frog_ast.BinaryNum(int(ctx.BINARYNUM().getText(), 2))
+            text = ctx.BINARYNUM().getText()
+            # text has form "0bXYZ"; the bit length is the number of digits
+            # after the "0b" prefix.
+            return frog_ast.BinaryNum(int(text, 2), len(text) - 2)
 
         if ctx.lvalue():
             exp = self.visit(ctx.lvalue())
@@ -986,7 +989,8 @@ class _SharedAST(PrimitiveVisitor, SchemeVisitor, GameVisitor, ProofVisitor):  #
     def visitBinaryNumExp(
         self, ctx: PrimitiveParser.BinaryNumExpContext
     ) -> frog_ast.BinaryNum:
-        return frog_ast.BinaryNum(int(ctx.BINARYNUM().getText(), 2))
+        text = ctx.BINARYNUM().getText()
+        return frog_ast.BinaryNum(int(text, 2), len(text) - 2)
 
     def visitZerosExp(
         self, ctx: PrimitiveParser.ZerosExpContext

--- a/proof_frog/semantic_analysis.py
+++ b/proof_frog/semantic_analysis.py
@@ -2,7 +2,7 @@ import os
 import sys
 import copy
 from typing import Optional, TypeVar, Union, TypeAlias
-from sympy import Rational, Symbol
+from sympy import Integer, Rational, Symbol
 from . import frog_ast
 from . import frog_parser
 from . import proof_engine
@@ -911,6 +911,14 @@ class CheckTypeVisitor(VariableTypeVisitor):
         self.subsets_pairs: list[tuple[PossibleType, PossibleType]] = (
             subsets_pairs if subsets_pairs is not None else []
         )
+        # Expression-level equality constraints from `requires e1 == e2;`
+        # where e1 and e2 are numeric expressions (e.g. `F.in == 1`).  These
+        # feed into the SymPy substitution dictionary used by compare_types
+        # to unify concrete BitString<n> against BitString<symbol> when a
+        # constraint pins the symbol to a concrete value.
+        self.expression_equality_pairs: list[
+            tuple[frog_ast.Expression, frog_ast.Expression]
+        ] = []
         self._instantiation_cache: dict[
             tuple[str, tuple[str, ...]], frog_ast.Instantiable
         ] = {}
@@ -1114,7 +1122,7 @@ class CheckTypeVisitor(VariableTypeVisitor):
             sym_val = _ast_to_sympy(ns_val)
             if sym_val is not None:
                 subs[Symbol(ns_name)] = sym_val
-        # From requires equality pairs
+        # From requires equality pairs (type-level)
         for left, right in self.subsets_pairs:
             if not isinstance(left, frog_ast.ASTNode) or not isinstance(
                 right, frog_ast.ASTNode
@@ -1128,6 +1136,16 @@ class CheckTypeVisitor(VariableTypeVisitor):
                 and isinstance(left_sym, Symbol)
             ):
                 subs[left_sym] = right_sym
+        # From requires equality pairs (expression-level, e.g. F.in == 1)
+        for left_expr, right_expr in self.expression_equality_pairs:
+            left_sym = _ast_to_sympy(left_expr)
+            right_sym = _ast_to_sympy(right_expr)
+            if left_sym is None or right_sym is None:
+                continue
+            if isinstance(left_sym, Symbol):
+                subs[left_sym] = right_sym
+            elif isinstance(right_sym, Symbol):
+                subs[right_sym] = left_sym
         return subs
 
     def check_types(
@@ -1223,10 +1241,22 @@ class CheckTypeVisitor(VariableTypeVisitor):
             frog_ast.BinaryOperators.SUBSETS,
             frog_ast.BinaryOperators.EQUALS,
         ):
-            if isinstance(expr.left_expression, frog_ast.Type) and isinstance(
-                expr.right_expression, frog_ast.Type
+            left = expr.left_expression
+            right = expr.right_expression
+            # Value-level equality such as `requires F.in == 1`: at least
+            # one operand is a pure Expression (Integer, BinaryOperation,
+            # etc.) that is not a Type node.  Record for SymPy substitution
+            # in compare_types.  Note: FieldAccess is both an Expression and
+            # a Type in the AST hierarchy, so we detect value-level pairs by
+            # the presence of a non-Type operand.
+            if expr.operator == frog_ast.BinaryOperators.EQUALS and (
+                not isinstance(left, frog_ast.Type)
+                or not isinstance(right, frog_ast.Type)
             ):
-                self.subsets_pairs.append((expr.left_expression, expr.right_expression))
+                self.expression_equality_pairs.append((left, right))
+                return
+            if isinstance(left, frog_ast.Type) and isinstance(right, frog_ast.Type):
+                self.subsets_pairs.append((left, right))
                 # Warn when a == constraint has the abstract type on the
                 # right, since the type normalizer only fires when the
                 # left side resolves to a Variable after instantiation.
@@ -1975,7 +2005,9 @@ class CheckTypeVisitor(VariableTypeVisitor):
         self.ast_type_map.set(field_acess, member)  # type: ignore[arg-type]
 
     def leave_binary_num(self, binary_num: frog_ast.BinaryNum) -> None:
-        self.ast_type_map.set(binary_num, frog_ast.BitStringType())
+        self.ast_type_map.set(
+            binary_num, frog_ast.BitStringType(frog_ast.Integer(binary_num.length))
+        )
 
     def leave_bit_string_literal(
         self, bit_string_literal: frog_ast.BitStringLiteral
@@ -2603,6 +2635,13 @@ def compare_types(
                 declared_type.parameterization
             )
             value_type_expression = get_sympy_expression(value_type.parameterization)
+            # get_sympy_expression returns a raw Python int for Integer
+            # literals; wrap so both sides expose .subs() for the
+            # substitution loop below.
+            if isinstance(declared_type_expression, int):
+                declared_type_expression = Integer(declared_type_expression)
+            if isinstance(value_type_expression, int):
+                value_type_expression = Integer(value_type_expression)
             if sympy_subs and declared_type_expression != value_type_expression:
                 # Apply Int field definitions and requires equalities
                 # iteratively until fixed point for transitive chains
@@ -2622,8 +2661,7 @@ def compare_types(
                         and value_type_expression == prev_v
                     ):
                         break
-            bool_value = declared_type_expression == value_type_expression
-            return bool_value
+            return bool(declared_type_expression == value_type_expression)
         return True
 
     if isinstance(declared_type, frog_ast.ModIntType) and isinstance(
@@ -2660,6 +2698,11 @@ def compare_types(
         v_count = get_sympy_expression(value_type.count)
         if d_count is None or v_count is None:
             return declared_type.count == value_type.count
+        # Wrap raw ints so both sides expose .subs() below.
+        if isinstance(d_count, int):
+            d_count = Integer(d_count)
+        if isinstance(v_count, int):
+            v_count = Integer(v_count)
         if sympy_subs and d_count != v_count:
             for _ in range(10):
                 prev_d, prev_v = d_count, v_count
@@ -2667,7 +2710,7 @@ def compare_types(
                 v_count = v_count.subs(sympy_subs)  # type: ignore[union-attr]
                 if d_count == prev_d and v_count == prev_v:
                     break
-        return d_count == v_count
+        return bool(d_count == v_count)
 
     return False
 

--- a/proof_frog/transforms/pipelines.py
+++ b/proof_frog/transforms/pipelines.py
@@ -21,6 +21,7 @@ from .random_functions import (
     UniqueRFSimplification,
     ChallengeExclusionRFToUniform,
     LocalRFToUniform,
+    DistinctConstRFToUniform,
     FreshInputRFToUniform,
 )
 from .inlining import (
@@ -92,6 +93,7 @@ CORE_PIPELINE: list[TransformPass] = [
     UniqueRFSimplification(),
     ChallengeExclusionRFToUniform(),
     LocalRFToUniform(),
+    DistinctConstRFToUniform(),
     FreshInputRFToUniform(),
     RedundantCopy(),
     InlineSingleUseVariable(),

--- a/proof_frog/transforms/random_functions.py
+++ b/proof_frog/transforms/random_functions.py
@@ -574,6 +574,300 @@ class LocalRFToUniform(TransformPass):
 
 
 # ---------------------------------------------------------------------------
+# Local RF called on distinct literal constants -> independent uniform samples
+# ---------------------------------------------------------------------------
+
+
+def _literal_key(expr: frog_ast.Expression) -> tuple[str, ...] | None:
+    """Return a canonical key for a literal bitstring expression.
+
+    The key is a tuple ``("bits", length_str, value_str)`` where:
+
+    - ``length_str`` stringifies the bit length (concrete integer or
+      symbolic expression).
+    - ``value_str`` stringifies the integer value that the literal
+      represents as an unsigned big-endian bitstring.
+
+    This unifies the two source-level literal forms:
+
+    - ``BinaryNum(num, length)`` directly provides the integer value.
+    - ``BitStringLiteral(bit=0, length=n)`` is the all-zero n-bit string,
+      integer value 0.
+    - ``BitStringLiteral(bit=1, length=n)`` is the all-one n-bit string,
+      integer value ``2^n - 1`` when ``n`` is a concrete integer.  When
+      ``n`` is symbolic (e.g. ``0^lambda``), the all-one value is also
+      symbolic; we encode it as ``"allones:<length_str>"`` to keep the
+      namespace disjoint from concrete values.
+
+    Two literals at the same call site have equal keys iff they represent
+    the same bitstring (the typechecker has already ensured they live in
+    the same type, so distinct keys imply distinct bitstring values).
+
+    Returns ``None`` if *expr* is not a recognized literal form.
+    """
+    if isinstance(expr, frog_ast.BinaryNum):
+        return ("bits", str(expr.length), str(expr.num))
+    if isinstance(expr, frog_ast.BitStringLiteral):
+        length_str = str(expr.length)
+        if expr.bit == 0:
+            return ("bits", length_str, "0")
+        # All-ones: if length is a concrete Integer literal, compute
+        # 2^n - 1; otherwise keep the symbolic marker so it does not
+        # collide with any numeric value.
+        if isinstance(expr.length, frog_ast.Integer):
+            value = (1 << expr.length.num) - 1
+            return ("bits", length_str, str(value))
+        return ("bits", length_str, f"allones:{length_str}")
+    return None
+
+
+def _collect_rf_call_args(
+    block: frog_ast.Block, rf_name: str
+) -> list[frog_ast.Expression] | None:
+    """Collect every argument expression passed to ``rf_name`` in *block*.
+
+    Returns ``None`` if the RF is referenced in any non-call position (e.g.,
+    ``RF.domain``, bare variable reference), which would block the transform.
+    """
+    args: list[frog_ast.Expression] = []
+    call_count, field_access_count = _count_rf_calls(block, rf_name)
+    if field_access_count > 0:
+        return None
+
+    # Walk the block to collect arguments in order.
+    def walk(node: frog_ast.ASTNode) -> bool:
+        if (
+            isinstance(node, frog_ast.FuncCall)
+            and isinstance(node.func, frog_ast.Variable)
+            and node.func.name == rf_name
+        ):
+            if len(node.args) == 1:
+                args.append(node.args[0])
+            # Return False so SearchVisitor continues searching elsewhere,
+            # but the call's own children will also be visited.  We tolerate
+            # that because the Variable child just gets ignored here — the
+            # conservative bare-reference check is handled separately below.
+            return False
+        return False
+
+    SearchVisitor(walk).visit(block)
+    if len(args) != call_count:
+        # Some call had a non-1-argument shape (should not happen for a
+        # Function<D, R> type, but guard defensively).
+        return None
+
+    # Ensure there are no bare references to the RF outside of FuncCall
+    # positions.  Every Variable("RF") inside the block is either the
+    # ``func`` field of a FuncCall we just collected (total ``call_count``
+    # of these) or a bare reference (which blocks us).
+    bare_refs = _count_variable_refs(block, rf_name)
+    if bare_refs != call_count:
+        return None
+
+    return args
+
+
+def _count_variable_refs(block: frog_ast.Block, name: str) -> int:
+    """Count every ``Variable(name)`` node appearing in *block*."""
+    count = [0]
+
+    def visitor(node: frog_ast.ASTNode) -> bool:
+        if isinstance(node, frog_ast.Variable) and node.name == name:
+            count[0] += 1
+        return False
+
+    SearchVisitor(visitor).visit(block)
+    return count[0]
+
+
+class _DistinctConstRFTransformer(BlockTransformer):
+    """Replace ``RF(c1), RF(c2), ..., RF(ck)`` with independent uniform
+    samples when RF is a locally-sampled random function, the ``ci`` are
+    pairwise-distinct literal constants, and RF has no other references.
+
+    Soundness: a freshly sampled ``Function<D, R>`` evaluated on *k*
+    pairwise-distinct domain points is distributed identically to *k*
+    independent uniform draws from ``R``.  The preconditions ensure this
+    equivalence:
+
+    - Local sample (not a field): each method invocation re-samples, so we
+      cannot violate consistency across oracle calls.
+    - No references other than the *k* call sites: the RF does not escape.
+    - No calls inside loop bodies: a single syntactic call inside a loop
+      would execute multiple times with the same input, yielding a single
+      shared value — independent samples would be unsound.
+    - All arguments are literal constants (``BinaryNum`` or
+      ``BitStringLiteral``) with pairwise-distinct canonical keys.  Both
+      forms carry explicit bit lengths in the AST (``BinaryNum.length`` from
+      the parser, ``BitStringLiteral.length`` from the source syntax), so
+      pairwise distinctness of keys is decided purely from the AST.  Since
+      typechecking has already enforced that every argument at the same
+      call site has the same width, distinct keys always represent distinct
+      bitstrings.
+    """
+
+    def __init__(self, ctx: PipelineContext | None = None) -> None:
+        self.ctx = ctx
+
+    def _transform_block_wrapper(
+        self, block: frog_ast.Block
+    ) -> frog_ast.Block:  # pylint: disable=too-many-locals,too-many-branches
+        for sample_idx, stmt in enumerate(block.statements):
+            if not (
+                isinstance(stmt, frog_ast.Sample)
+                and isinstance(stmt.sampled_from, frog_ast.FunctionType)
+                and isinstance(stmt.var, frog_ast.Variable)
+            ):
+                continue
+
+            rf_name = stmt.var.name
+            rf_type = stmt.sampled_from
+
+            if stmt.the_type is None:
+                has_decl = any(
+                    isinstance(s, frog_ast.VariableDeclaration)
+                    and s.name == rf_name
+                    and isinstance(s.type, frog_ast.FunctionType)
+                    for s in block.statements[:sample_idx]
+                )
+                if not has_decl:
+                    continue
+
+            remaining = frog_ast.Block(block.statements[sample_idx + 1 :])
+
+            call_args = _collect_rf_call_args(remaining, rf_name)
+            if call_args is None:
+                continue
+
+            # Need at least 2 calls to be interesting (k=1 is handled by
+            # LocalRFToUniform).
+            if len(call_args) < 2:
+                continue
+
+            if _rf_call_in_loop(remaining, rf_name):
+                continue
+
+            # All args must be literal constants with pairwise-distinct keys.
+            # Also require that every literal's declared length expression is
+            # structurally identical to every other: the typechecker has
+            # already accepted the call, so they should unify, but different
+            # structural forms could coincidentally represent the same length
+            # (e.g. `0^lambda` and `0^(F.in)` with `requires lambda == F.in`).
+            # Reject such cases conservatively since the equality check on
+            # the _literal_key value assumes a shared length namespace.
+            keys: list[tuple[str, ...]] = []
+            all_literal = True
+            literal_lengths: list[frog_ast.Expression] = []
+            for arg in call_args:
+                key = _literal_key(arg)
+                if key is None:
+                    all_literal = False
+                    break
+                keys.append(key)
+                if isinstance(arg, frog_ast.BinaryNum):
+                    literal_lengths.append(frog_ast.Integer(arg.length))
+                else:
+                    assert isinstance(arg, frog_ast.BitStringLiteral)
+                    literal_lengths.append(arg.length)
+            if all_literal and literal_lengths:
+                first_length = literal_lengths[0]
+                if not all(length == first_length for length in literal_lengths[1:]):
+                    if self.ctx is not None:
+                        self.ctx.near_misses.append(
+                            NearMiss(
+                                transform_name="Distinct Const RF To Uniform",
+                                reason=(
+                                    f"RF '{rf_name}' called with literal "
+                                    "arguments whose declared bit lengths "
+                                    "are not structurally identical"
+                                ),
+                                location=stmt.origin,
+                                suggestion=None,
+                                variable=rf_name,
+                                method=None,
+                            )
+                        )
+                    continue
+            if not all_literal:
+                if self.ctx is not None:
+                    self.ctx.near_misses.append(
+                        NearMiss(
+                            transform_name="Distinct Const RF To Uniform",
+                            reason=(
+                                f"RF '{rf_name}' called multiple times but at "
+                                "least one argument is not a literal constant"
+                            ),
+                            location=stmt.origin,
+                            suggestion=(
+                                "Use literal constants (e.g., 0b0, 0b1) as RF "
+                                "arguments so distinctness can be decided "
+                                "syntactically"
+                            ),
+                            variable=rf_name,
+                            method=None,
+                        )
+                    )
+                continue
+
+            if len(set(keys)) != len(keys):
+                if self.ctx is not None:
+                    self.ctx.near_misses.append(
+                        NearMiss(
+                            transform_name="Distinct Const RF To Uniform",
+                            reason=(
+                                f"RF '{rf_name}' called on duplicate literal "
+                                "arguments — cannot replace with independent "
+                                "samples"
+                            ),
+                            location=stmt.origin,
+                            suggestion=None,
+                            variable=rf_name,
+                            method=None,
+                        )
+                    )
+                continue
+
+            # No overflow guard is needed here: the typechecker assigns
+            # every BinaryNum its concrete source-level width, every
+            # BitStringLiteral its declared length, and the well-formedness
+            # of the call site guarantees every argument typechecks against
+            # the RF's declared domain type.  Two arguments at the same call
+            # site therefore always have the same bit width, and pairwise
+            # distinct keys always represent pairwise distinct bitstrings.
+
+            # Extract every RF call into a standalone assignment so that
+            # _RFCallReplacer can rewrite them uniformly into fresh samples.
+            extracted = _RFCallExtractor({rf_name}, {rf_name: rf_type}).transform(
+                remaining
+            )
+            replaced = _RFCallReplacer({rf_name: rf_type}).transform(extracted)
+
+            if replaced == remaining:
+                continue
+
+            # Drop the original RF sample (now dead) and splice in replaced.
+            new_stmts = list(block.statements[:sample_idx]) + list(replaced.statements)
+            return self.transform_block(frog_ast.Block(new_stmts))
+
+        return block
+
+
+class DistinctConstRFToUniform(TransformPass):
+    """Replace locally-sampled RFs called on distinct literal constants with
+    independent uniform samples.
+
+    Generalizes :class:`LocalRFToUniform` from k=1 to arbitrary k when the
+    arguments are syntactically-distinct literal constants (currently
+    ``BinaryNum`` only).
+    """
+
+    name = "Distinct Const RF To Uniform"
+
+    def apply(self, game: frog_ast.Game, ctx: PipelineContext) -> frog_ast.Game:
+        return _DistinctConstRFTransformer(ctx).transform(game)
+
+
+# ---------------------------------------------------------------------------
 # RF on fresh random local input -> uniform sample
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/parsing/test_bitstring_literals.py
+++ b/tests/unit/parsing/test_bitstring_literals.py
@@ -43,6 +43,29 @@ class TestParsing:
         expr = frog_parser.parse_expression("0b101")
         assert isinstance(expr, frog_ast.BinaryNum)
         assert expr.num == 5
+        assert expr.length == 3
+
+    def test_binary_num_length_zero_bit(self) -> None:
+        """0b0 is a 1-bit literal, not an unspecified-width literal."""
+        expr = frog_parser.parse_expression("0b0")
+        assert isinstance(expr, frog_ast.BinaryNum)
+        assert expr.num == 0
+        assert expr.length == 1
+
+    def test_binary_num_length_matches_source(self) -> None:
+        """The parser records the number of digits as the bit length."""
+        for src, expected_num, expected_length in [
+            ("0b00", 0, 2),
+            ("0b01", 1, 2),
+            ("0b10", 2, 2),
+            ("0b11", 3, 2),
+            ("0b000", 0, 3),
+            ("0b1000", 8, 4),
+        ]:
+            expr = frog_parser.parse_expression(src)
+            assert isinstance(expr, frog_ast.BinaryNum)
+            assert expr.num == expected_num, src
+            assert expr.length == expected_length, src
 
     def test_in_add_expression(self) -> None:
         expr = frog_parser.parse_expression("x + 0^3")

--- a/tests/unit/transforms/test_distinct_const_rf_to_uniform.py
+++ b/tests/unit/transforms/test_distinct_const_rf_to_uniform.py
@@ -1,0 +1,313 @@
+"""Tests for the DistinctConstRFToUniform transform pass."""
+
+import pytest
+from proof_frog import frog_parser
+from proof_frog.transforms.random_functions import _DistinctConstRFTransformer
+
+
+@pytest.mark.parametrize(
+    "method,expected",
+    [
+        # Basic: RF called twice on distinct literal constants -> two fresh samples
+        (
+            """
+            BitString<2> f() {
+                Function<BitString<1>, BitString<1>> RF;
+                RF <- Function<BitString<1>, BitString<1>>;
+                return RF(0b0) || RF(0b1);
+            }
+            """,
+            """
+            BitString<2> f() {
+                Function<BitString<1>, BitString<1>> RF;
+                BitString<1> __rf_extract_0__ <- BitString<1>;
+                BitString<1> __rf_extract_1__ <- BitString<1>;
+                return __rf_extract_0__ || __rf_extract_1__;
+            }
+            """,
+        ),
+        # Three distinct constants
+        (
+            """
+            BitString<6> f() {
+                Function<BitString<2>, BitString<2>> RF;
+                RF <- Function<BitString<2>, BitString<2>>;
+                BitString<2> a = RF(0b00);
+                BitString<2> b = RF(0b01);
+                BitString<2> c = RF(0b10);
+                return a || b || c;
+            }
+            """,
+            """
+            BitString<6> f() {
+                Function<BitString<2>, BitString<2>> RF;
+                BitString<2> a <- BitString<2>;
+                BitString<2> b <- BitString<2>;
+                BitString<2> c <- BitString<2>;
+                return a || b || c;
+            }
+            """,
+        ),
+        # NOT fired: duplicate constants (same num)
+        (
+            """
+            BitString<2> f() {
+                Function<BitString<1>, BitString<1>> RF;
+                RF <- Function<BitString<1>, BitString<1>>;
+                return RF(0b0) || RF(0b0);
+            }
+            """,
+            """
+            BitString<2> f() {
+                Function<BitString<1>, BitString<1>> RF;
+                RF <- Function<BitString<1>, BitString<1>>;
+                return RF(0b0) || RF(0b0);
+            }
+            """,
+        ),
+        # NOT fired: non-literal argument (variable)
+        (
+            """
+            BitString<2> f(BitString<1> x) {
+                Function<BitString<1>, BitString<1>> RF;
+                RF <- Function<BitString<1>, BitString<1>>;
+                return RF(0b0) || RF(x);
+            }
+            """,
+            """
+            BitString<2> f(BitString<1> x) {
+                Function<BitString<1>, BitString<1>> RF;
+                RF <- Function<BitString<1>, BitString<1>>;
+                return RF(0b0) || RF(x);
+            }
+            """,
+        ),
+        # NOT fired: only one call (handled by LocalRFToUniform instead)
+        (
+            """
+            BitString<1> f() {
+                Function<BitString<1>, BitString<1>> RF;
+                RF <- Function<BitString<1>, BitString<1>>;
+                return RF(0b0);
+            }
+            """,
+            """
+            BitString<1> f() {
+                Function<BitString<1>, BitString<1>> RF;
+                RF <- Function<BitString<1>, BitString<1>>;
+                return RF(0b0);
+            }
+            """,
+        ),
+        # NOT fired: RF also accessed via .domain
+        (
+            """
+            BitString<2> f() {
+                Function<BitString<1>, BitString<1>> RF;
+                RF <- Function<BitString<1>, BitString<1>>;
+                BitString<1> r <-uniq[RF.domain] BitString<1>;
+                return RF(0b0) || RF(0b1);
+            }
+            """,
+            """
+            BitString<2> f() {
+                Function<BitString<1>, BitString<1>> RF;
+                RF <- Function<BitString<1>, BitString<1>>;
+                BitString<1> r <-uniq[RF.domain] BitString<1>;
+                return RF(0b0) || RF(0b1);
+            }
+            """,
+        ),
+        # Fires: concrete-width BinaryNum domain with distinct literals
+        (
+            """
+            BitString<4> f() {
+                Function<BitString<2>, BitString<2>> RF;
+                RF <- Function<BitString<2>, BitString<2>>;
+                BitString<2> a = RF(0b01);
+                BitString<2> b = RF(0b10);
+                return a || b;
+            }
+            """,
+            """
+            BitString<4> f() {
+                Function<BitString<2>, BitString<2>> RF;
+                BitString<2> a <- BitString<2>;
+                BitString<2> b <- BitString<2>;
+                return a || b;
+            }
+            """,
+        ),
+        # Fires: BitStringLiteral arguments with distinct bit values
+        (
+            """
+            BitString<2> f() {
+                Function<BitString<1>, BitString<1>> RF;
+                RF <- Function<BitString<1>, BitString<1>>;
+                return RF(0^1) || RF(1^1);
+            }
+            """,
+            """
+            BitString<2> f() {
+                Function<BitString<1>, BitString<1>> RF;
+                BitString<1> __rf_extract_0__ <- BitString<1>;
+                BitString<1> __rf_extract_1__ <- BitString<1>;
+                return __rf_extract_0__ || __rf_extract_1__;
+            }
+            """,
+        ),
+        # NOT fired: BitStringLiteral with duplicate (bit, length) keys
+        (
+            """
+            BitString<2> f() {
+                Function<BitString<1>, BitString<1>> RF;
+                RF <- Function<BitString<1>, BitString<1>>;
+                return RF(0^1) || RF(0^1);
+            }
+            """,
+            """
+            BitString<2> f() {
+                Function<BitString<1>, BitString<1>> RF;
+                RF <- Function<BitString<1>, BitString<1>>;
+                return RF(0^1) || RF(0^1);
+            }
+            """,
+        ),
+        # NOT fired: 0b0 and 0^1 are the same 1-bit zero, so the keys
+        # collide and the transform must refuse (regression against a bug
+        # where disjoint keys per literal form would erroneously treat
+        # these as distinct inputs).
+        (
+            """
+            BitString<2> f() {
+                Function<BitString<1>, BitString<1>> RF;
+                RF <- Function<BitString<1>, BitString<1>>;
+                return RF(0b0) || RF(0^1);
+            }
+            """,
+            """
+            BitString<2> f() {
+                Function<BitString<1>, BitString<1>> RF;
+                RF <- Function<BitString<1>, BitString<1>>;
+                return RF(0b0) || RF(0^1);
+            }
+            """,
+        ),
+        # NOT fired: 0b1 (1-bit, value 1) and 1^1 (all-ones 1-bit) are
+        # the same bitstring, so keys collide.
+        (
+            """
+            BitString<2> f() {
+                Function<BitString<1>, BitString<1>> RF;
+                RF <- Function<BitString<1>, BitString<1>>;
+                return RF(0b1) || RF(1^1);
+            }
+            """,
+            """
+            BitString<2> f() {
+                Function<BitString<1>, BitString<1>> RF;
+                RF <- Function<BitString<1>, BitString<1>>;
+                return RF(0b1) || RF(1^1);
+            }
+            """,
+        ),
+        # Fires: 0b01 (2-bit, value 1) and 0b10 (2-bit, value 2) are
+        # distinct.
+        (
+            """
+            BitString<4> f() {
+                Function<BitString<2>, BitString<2>> RF;
+                RF <- Function<BitString<2>, BitString<2>>;
+                return RF(0b01) || RF(0b10);
+            }
+            """,
+            """
+            BitString<4> f() {
+                Function<BitString<2>, BitString<2>> RF;
+                BitString<2> __rf_extract_0__ <- BitString<2>;
+                BitString<2> __rf_extract_1__ <- BitString<2>;
+                return __rf_extract_0__ || __rf_extract_1__;
+            }
+            """,
+        ),
+        # Fires: 0b00 (2-bit, value 0) and 1^2 (all-ones 2-bit, value 3)
+        # are distinct across literal forms.
+        (
+            """
+            BitString<4> f() {
+                Function<BitString<2>, BitString<2>> RF;
+                RF <- Function<BitString<2>, BitString<2>>;
+                return RF(0b00) || RF(1^2);
+            }
+            """,
+            """
+            BitString<4> f() {
+                Function<BitString<2>, BitString<2>> RF;
+                BitString<2> __rf_extract_0__ <- BitString<2>;
+                BitString<2> __rf_extract_1__ <- BitString<2>;
+                return __rf_extract_0__ || __rf_extract_1__;
+            }
+            """,
+        ),
+        # NOT fired: literals have structurally-different length expressions
+        # (1-bit BinaryNum vs symbolic-length BitStringLiteral).  The
+        # transform refuses conservatively even though the method is
+        # presumably typechecked such that the lengths coincide.
+        (
+            """
+            BitString<2> f() {
+                Function<BitString<lambda>, BitString<1>> RF;
+                RF <- Function<BitString<lambda>, BitString<1>>;
+                return RF(0b0) || RF(1^lambda);
+            }
+            """,
+            """
+            BitString<2> f() {
+                Function<BitString<lambda>, BitString<1>> RF;
+                RF <- Function<BitString<lambda>, BitString<1>>;
+                return RF(0b0) || RF(1^lambda);
+            }
+            """,
+        ),
+        # NOT fired: RF call inside a loop body
+        (
+            """
+            BitString<1> f() {
+                Function<BitString<1>, BitString<1>> RF;
+                RF <- Function<BitString<1>, BitString<1>>;
+                BitString<1> z = RF(0b1);
+                for (Int i = 0 to 5) {
+                    z = RF(0b0);
+                }
+                return z;
+            }
+            """,
+            """
+            BitString<1> f() {
+                Function<BitString<1>, BitString<1>> RF;
+                RF <- Function<BitString<1>, BitString<1>>;
+                BitString<1> z = RF(0b1);
+                for (Int i = 0 to 5) {
+                    z = RF(0b0);
+                }
+                return z;
+            }
+            """,
+        ),
+    ],
+)
+def test_distinct_const_rf_to_uniform(
+    method: str,
+    expected: str,
+) -> None:
+    method_ast = frog_parser.parse_method(method)
+    expected_ast = frog_parser.parse_method(expected)
+    transformed_ast = method_ast
+    while True:
+        new_ast = _DistinctConstRFTransformer().transform(transformed_ast)
+        if new_ast == transformed_ast:
+            break
+        transformed_ast = new_ast
+    print("EXPECTED", expected_ast)
+    print("TRANSFORMED", transformed_ast)
+    assert expected_ast == transformed_ast

--- a/tests/unit/transforms/test_near_misses.py
+++ b/tests/unit/transforms/test_near_misses.py
@@ -16,7 +16,10 @@ from proof_frog.transforms.inlining import (
     DeduplicateDeterministicCalls,
 )
 from proof_frog.transforms.sampling import MergeUniformSamples, SplitUniformSamples
-from proof_frog.transforms.random_functions import LocalRFToUniform
+from proof_frog.transforms.random_functions import (
+    LocalRFToUniform,
+    DistinctConstRFToUniform,
+)
 from proof_frog.transforms.structural import UniformBijectionElimination
 from proof_frog.visitors import NameTypeMap
 
@@ -338,6 +341,69 @@ def test_local_rf_no_near_miss_when_no_rf():
     ctx = _make_ctx()
     LocalRFToUniform().apply(game, ctx)
     assert len(ctx.near_misses) == 0
+
+
+# ---------------------------------------------------------------------------
+# DistinctConstRFToUniform near-miss tests
+# ---------------------------------------------------------------------------
+
+
+def _make_bitstring1_rf_game(body: str) -> object:
+    """Parse a game with a BitString<1> Query method for RF-constant tests."""
+    src = (
+        "Game TestGame() {\n"
+        "    BitString<2> Query() {\n"
+        f"        {body}\n"
+        "    }\n"
+        "}"
+    )
+    return frog_parser.parse_game(src)
+
+
+def test_distinct_const_rf_near_miss_non_literal_arg():
+    """Reports near-miss when an RF argument is not a literal constant."""
+    game_src = (
+        "Game TestGame() {\n"
+        "    BitString<2> Query(BitString<1> x) {\n"
+        "        Function<BitString<1>, BitString<1>> RF "
+        "<- Function<BitString<1>, BitString<1>>;\n"
+        "        return RF(0b0) || RF(x);\n"
+        "    }\n"
+        "}"
+    )
+    game = frog_parser.parse_game(game_src)
+    ctx = _make_ctx()
+    DistinctConstRFToUniform().apply(game, ctx)
+    rf_misses = [nm for nm in ctx.near_misses if nm.variable == "RF"]
+    assert len(rf_misses) == 1
+    assert "literal" in rf_misses[0].reason.lower()
+
+
+def test_distinct_const_rf_near_miss_duplicate_literal():
+    """Reports near-miss when RF is called on duplicate literal constants."""
+    game = _make_bitstring1_rf_game(
+        "Function<BitString<1>, BitString<1>> RF "
+        "<- Function<BitString<1>, BitString<1>>;\n"
+        "        return RF(0b0) || RF(0b0);"
+    )
+    ctx = _make_ctx()
+    DistinctConstRFToUniform().apply(game, ctx)
+    rf_misses = [nm for nm in ctx.near_misses if nm.variable == "RF"]
+    assert len(rf_misses) == 1
+    assert "duplicate" in rf_misses[0].reason.lower()
+
+
+def test_distinct_const_rf_no_near_miss_when_fires():
+    """No near-miss when the transform successfully fires."""
+    game = _make_bitstring1_rf_game(
+        "Function<BitString<1>, BitString<1>> RF "
+        "<- Function<BitString<1>, BitString<1>>;\n"
+        "        return RF(0b0) || RF(0b1);"
+    )
+    ctx = _make_ctx()
+    DistinctConstRFToUniform().apply(game, ctx)
+    rf_misses = [nm for nm in ctx.near_misses if nm.variable == "RF"]
+    assert len(rf_misses) == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds a new canonicalization transform that replaces k>=2 calls to a locally-sampled Function<D, R> on pairwise-distinct literal constants with k independent uniform samples. Enables the CounterPRG length- doubling proof, whose PRF reduction composes with PRFSecurity.Random to produce RF(0^1) || RF(1^1), which this transform collapses into a single fresh 2*lambda sample.

Companion changes:

- BinaryNum carries an explicit length field (derived from source digits at parse time). Typed as BitString<length> instead of unparameterized BitString. Closes a class of soundness hazards where length-polymorphic literals could interact unsafely with transforms that reason about literal distinctness.
- compare_types no longer crashes on BitString<concrete> vs BitString<symbolic> (int.subs() AttributeError).
- compare_types propagates expression-level `requires` equalities (e.g. `requires F.in == 1`) via a new expression_equality_pairs field on CheckTypeVisitor, feeding the SymPy substitution pipeline. This lets BitString<1> unify with BitString<F.in> when the constraint pins the symbolic width, enabling 0^1 / 1^1 as arguments in CounterPRG.scheme.

The transform's canonical key space normalizes BinaryNum and BitStringLiteral into a shared ("bits", length, value) namespace so that RF(0b0) || RF(0^1) -- both representing the 1-bit zero -- is correctly rejected as a duplicate. Regression tests cover the cross-form collision cases.

Tests:
- tests/unit/transforms/test_distinct_const_rf_to_uniform.py (15 parameterized cases)
- tests/unit/transforms/test_near_misses.py (3 new cases)
- tests/unit/parsing/test_bitstring_literals.py (length field checks)