### PR TITLE
Replace str()-based sort keys with structural AST sort key

### DIFF
--- a/proof_frog/transforms/_ordering.py
+++ b/proof_frog/transforms/_ordering.py
@@ -1,0 +1,198 @@
+"""Structural sort key for AST nodes.
+
+Provides a single ``node_sort_key`` function that returns a recursively
+constructed tuple for any AST node.  The key is structural (based on AST
+shape), recursive, deterministic, and name-aware-but-name-secondary.
+
+Used by ``NormalizeCommutativeChains`` and ``StabilizeIndependentStatements``
+to order operands and statements without depending on ``__str__`` output.
+"""
+
+from __future__ import annotations
+
+from .. import frog_ast
+
+
+def node_sort_key(node: frog_ast.ASTNode) -> tuple:  # type: ignore[type-arg]
+    """Return a comparable tuple that captures the structural shape of *node*.
+
+    Type tags are fixed integers grouped by AST category so that simpler
+    nodes sort before complex ones:
+
+    - Expressions: 0-29
+    - Types: 30-49
+    - Statements: 50-69
+    - Fallback: 999
+    """
+    # -- Expressions (0-29) ---------------------------------------------------
+    # Variable also extends Type, but tag 0 is appropriate in both contexts.
+    if isinstance(node, frog_ast.Variable):
+        return (0, node.name)
+
+    if isinstance(node, frog_ast.Integer):
+        return (1, node.num)
+
+    if isinstance(node, frog_ast.Boolean):
+        return (2, int(node.bool))
+
+    if isinstance(node, frog_ast.NoneExpression):
+        return (3,)
+
+    if isinstance(node, frog_ast.BinaryNum):
+        return (4, node.num, node.length)
+
+    if isinstance(node, frog_ast.BitStringLiteral):
+        return (5, node.bit, node_sort_key(node.length))
+
+    if isinstance(node, frog_ast.GroupGenerator):
+        return (6, node_sort_key(node.group))
+
+    if isinstance(node, frog_ast.GroupOrder):
+        return (7, node_sort_key(node.group))
+
+    if isinstance(node, frog_ast.FieldAccess):
+        return (8, node_sort_key(node.the_object), node.name)
+
+    if isinstance(node, frog_ast.ArrayAccess):
+        return (9, node_sort_key(node.the_array), node_sort_key(node.index))
+
+    if isinstance(node, frog_ast.Slice):
+        return (
+            10,
+            node_sort_key(node.the_array),
+            node_sort_key(node.start),
+            node_sort_key(node.end),
+        )
+
+    if isinstance(node, frog_ast.UnaryOperation):
+        return (11, node.operator.name, node_sort_key(node.expression))
+
+    # BinaryOperation also extends Type; tag 12 in both contexts.
+    if isinstance(node, frog_ast.BinaryOperation):
+        return (
+            12,
+            node.operator.name,
+            node_sort_key(node.left_expression),
+            node_sort_key(node.right_expression),
+        )
+
+    if isinstance(node, frog_ast.FuncCall):
+        return (13, node_sort_key(node.func), *(node_sort_key(a) for a in node.args))
+
+    if isinstance(node, frog_ast.Tuple):
+        return (14, *(node_sort_key(v) for v in node.values))
+
+    if isinstance(node, frog_ast.Set):
+        return (15, *(node_sort_key(e) for e in node.elements))
+
+    if isinstance(node, frog_ast.ParameterizedGame):
+        return (16, node.name, *(node_sort_key(a) for a in node.args))
+
+    if isinstance(node, frog_ast.ConcreteGame):
+        return (17, node_sort_key(node.game), node.which)
+
+    # -- Types (30-49) --------------------------------------------------------
+    if isinstance(node, frog_ast.IntType):
+        return (30,)
+
+    if isinstance(node, frog_ast.BoolType):
+        return (31,)
+
+    if isinstance(node, frog_ast.Void):
+        return (32,)
+
+    if isinstance(node, frog_ast.BitStringType):
+        if node.parameterization is not None:
+            return (33, node_sort_key(node.parameterization))
+        return (33,)
+
+    if isinstance(node, frog_ast.ModIntType):
+        return (34, node_sort_key(node.modulus))
+
+    if isinstance(node, frog_ast.GroupType):
+        return (35,)
+
+    if isinstance(node, frog_ast.GroupElemType):
+        return (36, node_sort_key(node.group))
+
+    if isinstance(node, frog_ast.ArrayType):
+        return (37, node_sort_key(node.element_type), node_sort_key(node.count))
+
+    if isinstance(node, frog_ast.MapType):
+        return (38, node_sort_key(node.key_type), node_sort_key(node.value_type))
+
+    if isinstance(node, frog_ast.SetType):
+        if node.parameterization is not None:
+            return (39, node_sort_key(node.parameterization))
+        return (39,)
+
+    if isinstance(node, frog_ast.FunctionType):
+        return (40, node_sort_key(node.domain_type), node_sort_key(node.range_type))
+
+    if isinstance(node, frog_ast.OptionalType):
+        return (41, node_sort_key(node.the_type))
+
+    if isinstance(node, frog_ast.ProductType):
+        return (42, *(node_sort_key(t) for t in node.types))
+
+    # -- Statements (50-69) ---------------------------------------------------
+    if isinstance(node, frog_ast.Assignment):
+        type_key = node_sort_key(node.the_type) if node.the_type else ()
+        value_key = node_sort_key(node.value) if node.value else ()
+        return (50, node_sort_key(node.var), type_key, value_key)
+
+    if isinstance(node, frog_ast.Sample):
+        type_key = node_sort_key(node.the_type) if node.the_type else ()
+        return (
+            51,
+            node_sort_key(node.var),
+            type_key,
+            node_sort_key(node.sampled_from),
+        )
+
+    if isinstance(node, frog_ast.UniqueSample):
+        type_key = node_sort_key(node.the_type) if node.the_type else ()
+        return (
+            52,
+            node_sort_key(node.var),
+            type_key,
+            node_sort_key(node.unique_set),
+            node_sort_key(node.sampled_from),
+        )
+
+    if isinstance(node, frog_ast.ReturnStatement):
+        return (53, node_sort_key(node.expression))
+
+    if isinstance(node, frog_ast.IfStatement):
+        return (
+            54,
+            *(node_sort_key(c) for c in node.conditions),
+            *(node_sort_key(b) for b in node.blocks),
+        )
+
+    if isinstance(node, frog_ast.NumericFor):
+        return (
+            55,
+            node.name,
+            node_sort_key(node.start),
+            node_sort_key(node.end),
+            node_sort_key(node.block),
+        )
+
+    if isinstance(node, frog_ast.GenericFor):
+        return (
+            56,
+            node_sort_key(node.var_type),
+            node.var_name,
+            node_sort_key(node.over),
+            node_sort_key(node.block),
+        )
+
+    if isinstance(node, frog_ast.VariableDeclaration):
+        return (57, node_sort_key(node.type), node.name)
+
+    if isinstance(node, frog_ast.Block):
+        return (58, *(node_sort_key(s) for s in node.statements))
+
+    # -- Fallback -------------------------------------------------------------
+    return (999, str(node))

--- a/proof_frog/transforms/algebraic.py
+++ b/proof_frog/transforms/algebraic.py
@@ -23,6 +23,7 @@ from ..visitors import (
     build_game_type_map,
 )
 from ._base import TransformPass, PipelineContext, NearMiss, has_nondeterministic_call
+from ._ordering import node_sort_key
 
 # ---------------------------------------------------------------------------
 # Transformer classes (moved from visitors.py)
@@ -1034,14 +1035,23 @@ _COMMUTATIVE_ASSOCIATIVE_OPS = frozenset(
     {frog_ast.BinaryOperators.ADD, frog_ast.BinaryOperators.MULTIPLY}
 )
 
+# Operators that are commutative but NOT associative.
+# ==  and != are commutative (a == b iff b == a) but chaining them
+# ((a == b) == c) is not meaningful, so we only swap the two operands.
+_COMMUTATIVE_ONLY_OPS = frozenset(
+    {frog_ast.BinaryOperators.EQUALS, frog_ast.BinaryOperators.NOTEQUALS}
+)
+
 
 class NormalizeCommutativeChainsTransformer(Transformer):
-    """Sort operands of commutative+associative operator chains.
+    """Sort operands of commutative operator chains.
 
-    Flattens chains like ``(c + a) + b`` into ``[a, b, c]`` (sorted by
-    ``str()``), then rebuilds left-associatively as ``(a + b) + c``.
-    This normalizes both operand order (commutativity) and parenthesization
-    (associativity) in a single pass.
+    For commutative+associative operators (``+``, ``*``): flattens chains
+    like ``(c + a) + b`` into ``[a, b, c]`` (sorted by structural key),
+    then rebuilds left-associatively as ``(a + b) + c``.
+
+    For commutative-only operators (``==``, ``!=``): swaps operands so the
+    structurally smaller one is on the left.
     """
 
     def transform_binary_operation(
@@ -1054,19 +1064,30 @@ class NormalizeCommutativeChainsTransformer(Transformer):
             self.transform(expr.right_expression),
         )
 
-        if transformed.operator not in _COMMUTATIVE_ASSOCIATIVE_OPS:
-            return transformed
+        # Commutative + associative: flatten and sort the full chain.
+        if transformed.operator in _COMMUTATIVE_ASSOCIATIVE_OPS:
+            terms = _flatten_chain(transformed, transformed.operator)
+            if len(terms) < 2:
+                return transformed
 
-        terms = _flatten_chain(transformed, transformed.operator)
-        if len(terms) < 2:
-            return transformed
+            sorted_terms = sorted(terms, key=node_sort_key)
+            rebuilt = _rebuild_chain(sorted_terms, transformed.operator)
+            if rebuilt == transformed:
+                return transformed
+            return rebuilt
 
-        sorted_terms = sorted(terms, key=str)
-        rebuilt = _rebuild_chain(sorted_terms, transformed.operator)
-        if rebuilt == transformed:
-            return transformed  # already in canonical form
+        # Commutative only (== / !=): swap if left > right.
+        if transformed.operator in _COMMUTATIVE_ONLY_OPS:
+            left_key = node_sort_key(transformed.left_expression)
+            right_key = node_sort_key(transformed.right_expression)
+            if left_key > right_key:
+                return frog_ast.BinaryOperation(
+                    transformed.operator,
+                    transformed.right_expression,
+                    transformed.left_expression,
+                )
 
-        return rebuilt
+        return transformed
 
 
 class NormalizeCommutativeChains(TransformPass):

--- a/proof_frog/transforms/standardization.py
+++ b/proof_frog/transforms/standardization.py
@@ -21,6 +21,7 @@ from ..visitors import (
     FieldOrderingVisitor,
 )
 from ._base import TransformPass, PipelineContext
+from ._ordering import node_sort_key
 
 # ---------------------------------------------------------------------------
 # Transformer class (moved from visitors.py)
@@ -179,13 +180,13 @@ class _StabilizeIndependentStatementsTransformer(BlockTransformer):
         new_game.methods = [self.transform(m) for m in new_game.methods]
         return new_game
 
-    def _value_key(self, stmt: frog_ast.Statement) -> str:
-        """Sort key based on the RHS expression, ignoring the assigned name.
+    def _value_key(self, stmt: frog_ast.Statement) -> tuple:  # type: ignore[type-arg]
+        """Structural sort key for the RHS expression, ignoring the assigned name.
 
-        A prefix distinguishes field declarations from locals so that
-        fields sort deterministically before locals with the same RHS.
-        For field statements where the_type is None (type comes from the
-        field definition), sampled_from is used as the type component.
+        Returns a tuple built from ``node_sort_key`` so that ordering is
+        based on AST shape rather than ``__str__`` output.  A numeric
+        prefix distinguishes field declarations (0) from locals (1) so
+        that fields sort deterministically before locals.
         """
         is_field = (
             isinstance(
@@ -194,16 +195,20 @@ class _StabilizeIndependentStatementsTransformer(BlockTransformer):
             and isinstance(stmt.var, frog_ast.Variable)
             and stmt.var.name in self.fields
         )
-        prefix = "0_" if is_field else "1_"
+        prefix = (0,) if is_field else (1,)
         if isinstance(stmt, frog_ast.Assignment):
-            type_str = str(stmt.the_type) if stmt.the_type else ""
+            type_key = node_sort_key(stmt.the_type) if stmt.the_type else ()
             if stmt.value is not None:
-                return prefix + type_str + " = " + str(stmt.value)
-            return ""
+                return prefix + (type_key, node_sort_key(stmt.value))
+            return ()
         if isinstance(stmt, (frog_ast.Sample, frog_ast.UniqueSample)):
-            type_str = str(stmt.the_type) if stmt.the_type else str(stmt.sampled_from)
-            return prefix + type_str + " <- " + str(stmt.sampled_from)
-        return ""
+            type_key = (
+                node_sort_key(stmt.the_type)
+                if stmt.the_type
+                else node_sort_key(stmt.sampled_from)
+            )
+            return prefix + (type_key, node_sort_key(stmt.sampled_from))
+        return ()
 
     def _is_typed_decl(self, stmt: frog_ast.Statement) -> bool:
         if not isinstance(
@@ -388,7 +393,7 @@ class _StabilizeIndependentStatementsTransformer(BlockTransformer):
         # For locals: sort by value expression, then variable name.
         max_rank = len(stmts)
 
-        def _heap_key(i: int) -> tuple[int, int, str, str, int]:
+        def _heap_key(i: int) -> tuple:  # type: ignore[type-arg]
             rank = return_ranks.get(i, max_rank)
             s = stmts[i]
             name = ""

--- a/tests/unit/transforms/test_normalize_commutative.py
+++ b/tests/unit/transforms/test_normalize_commutative.py
@@ -112,6 +112,58 @@ from proof_frog.transforms.algebraic import NormalizeCommutativeChainsTransforme
             }
             """,
         ),
+        # Equality: b == a -> a == b
+        (
+            """
+            Bool f(BitString<lambda> a, BitString<lambda> b) {
+                return b == a;
+            }
+            """,
+            """
+            Bool f(BitString<lambda> a, BitString<lambda> b) {
+                return a == b;
+            }
+            """,
+        ),
+        # Equality: already sorted unchanged
+        (
+            """
+            Bool f(BitString<lambda> a, BitString<lambda> b) {
+                return a == b;
+            }
+            """,
+            """
+            Bool f(BitString<lambda> a, BitString<lambda> b) {
+                return a == b;
+            }
+            """,
+        ),
+        # Inequality: b != a -> a != b
+        (
+            """
+            Bool f(BitString<lambda> a, BitString<lambda> b) {
+                return b != a;
+            }
+            """,
+            """
+            Bool f(BitString<lambda> a, BitString<lambda> b) {
+                return a != b;
+            }
+            """,
+        ),
+        # Structural ordering for equality: FuncCall sorts after Variable
+        (
+            """
+            Bool f(Int a, Int b) {
+                return f(a) == a;
+            }
+            """,
+            """
+            Bool f(Int a, Int b) {
+                return a == f(a);
+            }
+            """,
+        ),
     ],
 )
 def test_normalize_commutative_chains(method: str, expected: str) -> None:

--- a/tests/unit/transforms/test_ordering.py
+++ b/tests/unit/transforms/test_ordering.py
@@ -1,0 +1,305 @@
+"""Tests for the structural AST sort key (node_sort_key)."""
+
+import inspect
+
+import pytest
+
+from proof_frog import frog_ast
+from proof_frog.transforms._ordering import node_sort_key
+
+
+# ---------------------------------------------------------------------------
+# Completeness: every concrete ASTNode subclass is covered
+# ---------------------------------------------------------------------------
+
+def _concrete_subclasses(base: type) -> set[type]:
+    """Recursively collect all non-abstract concrete subclasses of *base*."""
+    result: set[type] = set()
+    for cls in base.__subclasses__():
+        if not inspect.isabstract(cls):
+            result.add(cls)
+        result |= _concrete_subclasses(cls)
+    return result
+
+
+# Nodes that are containers / non-canonical and not expected in sort contexts.
+_EXCLUDED = {
+    # Abstract base classes
+    frog_ast.Expression,
+    frog_ast.Type,
+    frog_ast.Statement,
+    # Top-level containers (not part of game ASTs)
+    frog_ast.Root,
+    frog_ast.Primitive,
+    frog_ast.Scheme,
+    frog_ast.Game,
+    frog_ast.Reduction,
+    frog_ast.GameFile,
+    frog_ast.Method,
+    frog_ast.MethodSignature,
+    frog_ast.Field,
+    frog_ast.Parameter,
+    frog_ast.Import,
+    # Proof-file-level nodes (never appear inside game canonicalization)
+    frog_ast.ProofFile,
+    frog_ast.Step,
+    frog_ast.StepAssumption,
+    frog_ast.Induction,
+    frog_ast.Lemma,
+}
+
+# Factory functions that build a minimal instance of each covered type.
+_FACTORIES: dict[type, frog_ast.ASTNode] = {
+    frog_ast.Variable: frog_ast.Variable("x"),
+    frog_ast.Integer: frog_ast.Integer(0),
+    frog_ast.Boolean: frog_ast.Boolean(True),
+    frog_ast.NoneExpression: frog_ast.NoneExpression(),
+    frog_ast.BinaryNum: frog_ast.BinaryNum(0, 1),
+    frog_ast.BitStringLiteral: frog_ast.BitStringLiteral(0, frog_ast.Variable("n")),
+    frog_ast.GroupGenerator: frog_ast.GroupGenerator(frog_ast.Variable("G")),
+    frog_ast.GroupOrder: frog_ast.GroupOrder(frog_ast.Variable("G")),
+    frog_ast.FieldAccess: frog_ast.FieldAccess(frog_ast.Variable("x"), "f"),
+    frog_ast.ArrayAccess: frog_ast.ArrayAccess(
+        frog_ast.Variable("arr"), frog_ast.Integer(0)
+    ),
+    frog_ast.Slice: frog_ast.Slice(
+        frog_ast.Variable("arr"), frog_ast.Integer(0), frog_ast.Integer(1)
+    ),
+    frog_ast.UnaryOperation: frog_ast.UnaryOperation(
+        frog_ast.UnaryOperators.NOT, frog_ast.Boolean(True)
+    ),
+    frog_ast.BinaryOperation: frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.ADD, frog_ast.Variable("a"), frog_ast.Variable("b")
+    ),
+    frog_ast.FuncCall: frog_ast.FuncCall(frog_ast.Variable("f"), []),
+    frog_ast.Tuple: frog_ast.Tuple([frog_ast.Integer(1)]),
+    frog_ast.Set: frog_ast.Set([]),
+    frog_ast.ParameterizedGame: frog_ast.ParameterizedGame("G", []),
+    frog_ast.ConcreteGame: frog_ast.ConcreteGame(
+        frog_ast.ParameterizedGame("G", []), "Left"
+    ),
+    # Types
+    frog_ast.IntType: frog_ast.IntType(),
+    frog_ast.BoolType: frog_ast.BoolType(),
+    frog_ast.Void: frog_ast.Void(),
+    frog_ast.BitStringType: frog_ast.BitStringType(frog_ast.Variable("n")),
+    frog_ast.ModIntType: frog_ast.ModIntType(frog_ast.Variable("q")),
+    frog_ast.GroupType: frog_ast.GroupType(),
+    frog_ast.GroupElemType: frog_ast.GroupElemType(frog_ast.Variable("G")),
+    frog_ast.ArrayType: frog_ast.ArrayType(frog_ast.IntType(), frog_ast.Integer(10)),
+    frog_ast.MapType: frog_ast.MapType(frog_ast.IntType(), frog_ast.BoolType()),
+    frog_ast.SetType: frog_ast.SetType(frog_ast.IntType()),
+    frog_ast.FunctionType: frog_ast.FunctionType(frog_ast.IntType(), frog_ast.BoolType()),
+    frog_ast.OptionalType: frog_ast.OptionalType(frog_ast.IntType()),
+    frog_ast.ProductType: frog_ast.ProductType([frog_ast.IntType()]),
+    # Statements
+    frog_ast.Assignment: frog_ast.Assignment(
+        frog_ast.IntType(), frog_ast.Variable("x"), frog_ast.Integer(1)
+    ),
+    frog_ast.Sample: frog_ast.Sample(
+        frog_ast.BitStringType(frog_ast.Variable("n")),
+        frog_ast.Variable("r"),
+        frog_ast.BitStringType(frog_ast.Variable("n")),
+    ),
+    frog_ast.UniqueSample: frog_ast.UniqueSample(
+        frog_ast.BitStringType(frog_ast.Variable("n")),
+        frog_ast.Variable("r"),
+        frog_ast.Variable("S"),
+        frog_ast.BitStringType(frog_ast.Variable("n")),
+    ),
+    frog_ast.ReturnStatement: frog_ast.ReturnStatement(frog_ast.Integer(0)),
+    frog_ast.IfStatement: frog_ast.IfStatement(
+        [frog_ast.Boolean(True)],
+        [frog_ast.Block([frog_ast.ReturnStatement(frog_ast.Integer(0))])],
+    ),
+    frog_ast.NumericFor: frog_ast.NumericFor(
+        "i",
+        frog_ast.Integer(0),
+        frog_ast.Integer(10),
+        frog_ast.Block([]),
+    ),
+    frog_ast.GenericFor: frog_ast.GenericFor(
+        frog_ast.IntType(),
+        "x",
+        frog_ast.Variable("S"),
+        frog_ast.Block([]),
+    ),
+    frog_ast.VariableDeclaration: frog_ast.VariableDeclaration(
+        frog_ast.IntType(), "x"
+    ),
+    frog_ast.Block: frog_ast.Block([]),
+}
+
+
+def test_completeness() -> None:
+    """Every concrete ASTNode subclass should be covered by node_sort_key."""
+    all_concrete = _concrete_subclasses(frog_ast.ASTNode) - _EXCLUDED
+    covered = set(_FACTORIES.keys())
+    missing = all_concrete - covered
+    assert not missing, f"node_sort_key has no test factory for: {missing}"
+
+    # Verify none of the covered types fall through to the (999, ...) fallback.
+    for cls, instance in _FACTORIES.items():
+        key = node_sort_key(instance)
+        assert key[0] != 999, f"{cls.__name__} fell through to fallback"
+
+
+# ---------------------------------------------------------------------------
+# Structural ordering: tag determines primary order
+# ---------------------------------------------------------------------------
+
+def test_expression_tag_ordering() -> None:
+    """Simpler expression types sort before complex ones."""
+    var = frog_ast.Variable("z")
+    integer = frog_ast.Integer(0)
+    binop = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.ADD, frog_ast.Variable("a"), frog_ast.Variable("b")
+    )
+    func = frog_ast.FuncCall(frog_ast.Variable("f"), [frog_ast.Variable("x")])
+
+    assert node_sort_key(var) < node_sort_key(integer)
+    assert node_sort_key(integer) < node_sort_key(binop)
+    assert node_sort_key(binop) < node_sort_key(func)
+
+
+def test_type_tag_ordering() -> None:
+    """Type nodes sort by tag."""
+    assert node_sort_key(frog_ast.IntType()) < node_sort_key(
+        frog_ast.BitStringType(frog_ast.Variable("n"))
+    )
+    assert node_sort_key(frog_ast.BitStringType(frog_ast.Variable("n"))) < node_sort_key(
+        frog_ast.GroupElemType(frog_ast.Variable("G"))
+    )
+
+
+def test_statement_tag_ordering() -> None:
+    """Statement nodes sort by tag."""
+    assign = frog_ast.Assignment(
+        frog_ast.IntType(), frog_ast.Variable("x"), frog_ast.Integer(1)
+    )
+    sample = frog_ast.Sample(
+        frog_ast.BitStringType(frog_ast.Variable("n")),
+        frog_ast.Variable("r"),
+        frog_ast.BitStringType(frog_ast.Variable("n")),
+    )
+    ret = frog_ast.ReturnStatement(frog_ast.Integer(0))
+
+    assert node_sort_key(assign) < node_sort_key(sample)
+    assert node_sort_key(sample) < node_sort_key(ret)
+
+
+# ---------------------------------------------------------------------------
+# Same-type tiebreaking
+# ---------------------------------------------------------------------------
+
+def test_variable_name_tiebreaking() -> None:
+    assert node_sort_key(frog_ast.Variable("a")) < node_sort_key(frog_ast.Variable("b"))
+
+
+def test_integer_value_tiebreaking() -> None:
+    assert node_sort_key(frog_ast.Integer(1)) < node_sort_key(frog_ast.Integer(2))
+
+
+def test_boolean_value_tiebreaking() -> None:
+    # False (0) < True (1)
+    assert node_sort_key(frog_ast.Boolean(False)) < node_sort_key(
+        frog_ast.Boolean(True)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Recursive structure
+# ---------------------------------------------------------------------------
+
+def test_recursive_binop_ordering() -> None:
+    """a + b < a + c because b < c."""
+    ab = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.ADD, frog_ast.Variable("a"), frog_ast.Variable("b")
+    )
+    ac = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.ADD, frog_ast.Variable("a"), frog_ast.Variable("c")
+    )
+    assert node_sort_key(ab) < node_sort_key(ac)
+
+
+def test_operator_name_ordering() -> None:
+    """Different operators on same operands: sorted by operator name string."""
+    add = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.ADD, frog_ast.Variable("a"), frog_ast.Variable("b")
+    )
+    mul = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.MULTIPLY,
+        frog_ast.Variable("a"),
+        frog_ast.Variable("b"),
+    )
+    # "ADD" < "MULTIPLY"
+    assert node_sort_key(add) < node_sort_key(mul)
+
+
+def test_funccall_arg_ordering() -> None:
+    """FuncCalls with same function sorted by arguments."""
+    f_a = frog_ast.FuncCall(frog_ast.Variable("f"), [frog_ast.Variable("a")])
+    f_b = frog_ast.FuncCall(frog_ast.Variable("f"), [frog_ast.Variable("b")])
+    assert node_sort_key(f_a) < node_sort_key(f_b)
+
+
+# ---------------------------------------------------------------------------
+# Motivating case: structural complexity beats name
+# ---------------------------------------------------------------------------
+
+def test_variable_sorts_before_complex_expression() -> None:
+    """Variable("field2") < BinaryOp(EXPONENTIATE, Variable("field1"), Variable("aprime")).
+
+    This is the motivating case: a simple variable should sort before a
+    complex expression regardless of the variable names involved.
+    """
+    simple = frog_ast.Variable("field2")
+    complex_expr = frog_ast.BinaryOperation(
+        frog_ast.BinaryOperators.EXPONENTIATE,
+        frog_ast.Variable("field1"),
+        frog_ast.Variable("aprime"),
+    )
+    assert node_sort_key(simple) < node_sort_key(complex_expr)
+
+
+# ---------------------------------------------------------------------------
+# Cross-category ordering: expressions < types < statements
+# ---------------------------------------------------------------------------
+
+def test_expression_sorts_before_type() -> None:
+    assert node_sort_key(frog_ast.Variable("x")) < node_sort_key(frog_ast.IntType())
+
+
+def test_type_sorts_before_statement() -> None:
+    assign = frog_ast.Assignment(
+        frog_ast.IntType(), frog_ast.Variable("x"), frog_ast.Integer(1)
+    )
+    assert node_sort_key(frog_ast.IntType()) < node_sort_key(assign)
+
+
+# ---------------------------------------------------------------------------
+# Optional / None fields
+# ---------------------------------------------------------------------------
+
+def test_bitstring_type_unparameterized() -> None:
+    """Unparameterized BitStringType produces a shorter tuple."""
+    unparameterized = frog_ast.BitStringType()
+    parameterized = frog_ast.BitStringType(frog_ast.Variable("n"))
+    # (33,) < (33, (0, "n"))
+    assert node_sort_key(unparameterized) < node_sort_key(parameterized)
+
+
+def test_set_type_unparameterized() -> None:
+    unparameterized = frog_ast.SetType()
+    parameterized = frog_ast.SetType(frog_ast.IntType())
+    assert node_sort_key(unparameterized) < node_sort_key(parameterized)
+
+
+# ---------------------------------------------------------------------------
+# Determinism: same node always produces the same key
+# ---------------------------------------------------------------------------
+
+def test_determinism() -> None:
+    """Calling node_sort_key twice on the same node produces identical keys."""
+    for instance in _FACTORIES.values():
+        assert node_sort_key(instance) == node_sort_key(instance)


### PR DESCRIPTION
Introduce node_sort_key() in proof_frog/transforms/_ordering.py, a unified structural sort key that returns recursively constructed tuples (type_tag, *children) for AST nodes. This replaces ad-hoc str()-based sorting in NormalizeCommutativeChains and StabilizeIndependentStatements.

The structural key sorts by AST shape first (simpler nodes before complex ones) and uses names only as tiebreakers, fixing cases where str()-based ordering produced unintuitive results (e.g., Variable("field2") sorting after BinaryOperation(EXPONENTIATE, ...)).

Also extends NormalizeCommutativeChains to normalize == and != operand order (commutative but not associative), placing the structurally smaller operand on the left.