### PR TITLE
Update test references for renamed Group assumptions

### DIFF
--- a/tests/integration/test_web_server.py
+++ b/tests/integration/test_web_server.py
@@ -215,10 +215,11 @@ def test_inlined_game_endpoint_with_reduction_reference(examples_client):
     minimal-proof builder skipped Reduction blocks and the user got an
     `Error: \\`R_DDH'` parser failure."""
     c, examples_root = examples_client
-    rel = "Proofs/Group/DDHImpliesHashedDDH.proof"
+    rel = "Proofs/Group/DDHMultiChalImpliesHashedDDHMultiChal.proof"
     content = (examples_root / rel).read_text(encoding="utf-8")
     step_text = (
-        "DDH(G).Left compose R_DDH(G, n, H) against HashedDDH(G, n, H).Adversary"
+        "DDHMultiChal(G).Left compose R_DDH(G, n, H)"
+        " against HashedDDHMultiChal(G, n, H).Adversary"
     )
     resp = c.post(
         "/api/inlined-game",

--- a/tests/unit/transforms/test_counter_guarded_field_to_local.py
+++ b/tests/unit/transforms/test_counter_guarded_field_to_local.py
@@ -349,7 +349,7 @@ from proof_frog.transforms.sampling import _counter_guarded_field_to_local
         # Counter increment with operands in flipped order: `count = 1 + count`.
         # NormalizeCommutativeChains rewrites `count + 1` into `1 + count`
         # (integer literal first), so the pattern matcher must accept either
-        # operand order.  Regression test for the CDH=>OneTimeHashedDDH proof
+        # operand order.  Regression test for the CDH=>HashedDDH proof
         # which only canonicalized correctly after this fix.
         (
             """


### PR DESCRIPTION
Update test_web_server.py and test_counter_guarded_field_to_local.py to reflect the DDH/CDH/HashedDDH game renaming in the examples submodule.