### PR TITLE
Update test file paths to match renamed examples

### DIFF
--- a/tests/integration/test_file_metadata.py
+++ b/tests/integration/test_file_metadata.py
@@ -85,19 +85,19 @@ class TestSchemeMetadata:
 
 class TestGameMetadata:
     def test_basic_fields(self, client):
-        resp = client.get("/api/file-metadata?path=Games/PRG/Security.game")
+        resp = client.get("/api/file-metadata?path=Games/PRG/PRGSecurity.game")
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["type"] == "game"
-        assert data["export_name"] == "Security"
+        assert data["export_name"] == "PRGSecurity"
 
     def test_sides(self, client):
-        resp = client.get("/api/file-metadata?path=Games/PRG/Security.game")
+        resp = client.get("/api/file-metadata?path=Games/PRG/PRGSecurity.game")
         data = resp.get_json()
         assert data["sides"] == ["Real", "Random"]
 
     def test_games_list(self, client):
-        resp = client.get("/api/file-metadata?path=Games/PRG/Security.game")
+        resp = client.get("/api/file-metadata?path=Games/PRG/PRGSecurity.game")
         data = resp.get_json()
         assert len(data["games"]) == 2
         game_names = [g["name"] for g in data["games"]]
@@ -105,7 +105,7 @@ class TestGameMetadata:
         assert "Random" in game_names
 
     def test_game_structure(self, client):
-        resp = client.get("/api/file-metadata?path=Games/PRG/Security.game")
+        resp = client.get("/api/file-metadata?path=Games/PRG/PRGSecurity.game")
         data = resp.get_json()
         for g in data["games"]:
             assert "name" in g
@@ -116,14 +116,14 @@ class TestGameMetadata:
             assert isinstance(g["methods"], list)
 
     def test_game_parameters(self, client):
-        resp = client.get("/api/file-metadata?path=Games/PRG/Security.game")
+        resp = client.get("/api/file-metadata?path=Games/PRG/PRGSecurity.game")
         data = resp.get_json()
         real_game = data["games"][0]
         assert len(real_game["parameters"]) >= 1
         assert real_game["parameters"][0]["name"] == "G"
 
     def test_game_methods(self, client):
-        resp = client.get("/api/file-metadata?path=Games/PRG/Security.game")
+        resp = client.get("/api/file-metadata?path=Games/PRG/PRGSecurity.game")
         data = resp.get_json()
         real_game = data["games"][0]
         assert any("Query" in m for m in real_game["methods"])

--- a/tests/integration/test_scaffolding.py
+++ b/tests/integration/test_scaffolding.py
@@ -12,8 +12,8 @@ from proof_frog.web_server import create_app
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 EXAMPLES_DIR = REPO_ROOT / "examples"
-HYBRID_REL = "Proofs/PubEnc/Hybrid.proof"
-MULTIKEY_REL = "Proofs/PRF/MultiKeyFromPRF.proof"
+HYBRID_REL = "Proofs/PubKeyEnc/HybridPKEDEM_INDCPA_MultiChal.proof"
+MULTIKEY_REL = "Proofs/PRF/PRFSecurity_implies_PRFSecurity_MultiKey.proof"
 
 
 @pytest.fixture
@@ -156,7 +156,7 @@ def _reduction_payload(content, **overrides):
         "path": HYBRID_REL,
         "content": content,
         "name": "R_test",
-        "security_game_name": "CPA",
+        "security_game_name": "INDCPA_MultiChal",
         "side": "Left",
         "params": "SymEnc E, PubKeyEnc P, Hybrid H",
         "compose_args": "P",
@@ -176,8 +176,8 @@ def test_scaffold_reduction_smoke(client):
     assert "Reduction R_test(SymEnc E, PubKeyEnc P, Hybrid H)" in block
     # Reduction declarations don't carry the side — that's chosen at the
     # use site in the games: list. The side argument is validated only.
-    assert "compose CPA(P)" in block
-    assert "against CPA(H).Adversary" in block
+    assert "compose INDCPA_MultiChal(P)" in block
+    assert "against INDCPA_MultiChal(H).Adversary" in block
     # Substitution test: theorem-substituted form, not the security game's
     # formal `E`. This is the bug-fix assertion.
     assert "H.Ciphertext Challenge(H.Message mL, H.Message mR)" in block
@@ -274,11 +274,11 @@ def test_scaffold_reduction_hop_smoke(client):
     lines = body["lines"]
     assert len(lines) == 2
     assert (
-        "PRFSecurity(F).Real compose R_Hybrid against MultiKeyPRFSecurity(F).Adversary;"
+        "PRFSecurity(F).Real compose R_Hybrid against PRFSecurity_MultiKey(F).Adversary;"
         in lines[0]
     )
     assert (
-        "PRFSecurity(F).Random compose R_Hybrid against MultiKeyPRFSecurity(F).Adversary;"
+        "PRFSecurity(F).Random compose R_Hybrid against PRFSecurity_MultiKey(F).Adversary;"
         in lines[1]
     )
     # 4-space indentation matching games: block.
@@ -299,13 +299,13 @@ def test_scaffold_reduction_hop_parses_when_spliced(client):
     lines = resp.get_json()["lines"]
 
     # Splice the two lines in just after the first existing games: line.
-    marker = "MultiKeyPRFSecurity(F).Real against MultiKeyPRFSecurity(F).Adversary;"
+    marker = "PRFSecurity_MultiKey(F).Real against PRFSecurity_MultiKey(F).Adversary;"
     spliced = content.replace(
         marker,
         marker + "\n" + lines[0] + "\n" + lines[1],
         1,
     )
-    spliced_path = proof_path.with_name("MultiKeyFromPRF_hop_spliced.proof")
+    spliced_path = proof_path.with_name("PRFSecurity_MultiKey_hop_spliced.proof")
     spliced_path.write_text(spliced, encoding="utf-8")
     frog_parser.parse_proof_file(str(spliced_path))
 
@@ -322,13 +322,13 @@ def test_scaffold_reduction_hop_typechecks_when_spliced(client):
     assert resp.status_code == 200
     lines = resp.get_json()["lines"]
 
-    marker = "MultiKeyPRFSecurity(F).Real against MultiKeyPRFSecurity(F).Adversary;"
+    marker = "PRFSecurity_MultiKey(F).Real against PRFSecurity_MultiKey(F).Adversary;"
     spliced = content.replace(
         marker,
         marker + "\n" + lines[0] + "\n" + lines[1],
         1,
     )
-    spliced_path = proof_path.with_name("MultiKeyFromPRF_hop_typed.proof")
+    spliced_path = proof_path.with_name("PRFSecurity_MultiKey_hop_typed.proof")
     spliced_path.write_text(spliced, encoding="utf-8")
 
     parsed = frog_parser.parse_proof_file(str(spliced_path))

--- a/tests/integration/test_web_server.py
+++ b/tests/integration/test_web_server.py
@@ -56,22 +56,12 @@ def test_file_metadata_post_uses_request_content(client):
 
 
 def test_file_metadata_proof_resolves_renamed_import_assumption(examples_client):
-    """Regression test: an `import '...' as Alias;` clause must let the proof
-    metadata resolve assumption game references via the alias and return the
-    game's side names. This is what the Insert Reduction Hop wizard relies on
-    to populate its Direction dropdown.
-
-    `examples/Proofs/PRF/MultiKeyFromPRF.proof` has:
-        import '../../Games/PRF/Security.game' as PRFSecurity;
-        ...
-        assume:
-            PRFSecurity(F);
-
-    The basename of the imported file is `Security`, but the proof references
-    it via the alias `PRFSecurity`. Resolution must use the alias.
+    """The proof file imports PRFSecurity.game and references PRFSecurity(F)
+    in its assume: block. The metadata must resolve this and return the
+    game's side names for the Insert Reduction Hop wizard.
     """
     c, examples_root = examples_client
-    rel = "Proofs/PRF/MultiKeyFromPRF.proof"
+    rel = "Proofs/PRF/PRFSecurity_implies_PRFSecurity_MultiKey.proof"
     content = (examples_root / rel).read_text(encoding="utf-8")
     resp = c.post(
         "/api/file-metadata",
@@ -87,16 +77,15 @@ def test_file_metadata_proof_resolves_renamed_import_assumption(examples_client)
     assumption_names = [d["name"] for d in details]
     assert "PRFSecurity" in assumption_names
     prf_entry = next(d for d in details if d["name"] == "PRFSecurity")
-    # The imported Security.game has Real and Random sides.
     assert "Real" in prf_entry["sides"]
     assert "Random" in prf_entry["sides"]
 
 
 def test_file_metadata_proof_resolves_theorem_with_export_rename(examples_client):
-    """The theorem of MultiKeyFromPRF.proof references MultiKeyPRFSecurity,
-    which is the export name of MultiKey.game (filename != export name)."""
+    """The theorem of PRFSecurity_implies_PRFSecurity_MultiKey.proof
+    references PRFSecurity_MultiKey, which is the export name of the game."""
     c, examples_root = examples_client
-    rel = "Proofs/PRF/MultiKeyFromPRF.proof"
+    rel = "Proofs/PRF/PRFSecurity_implies_PRFSecurity_MultiKey.proof"
     content = (examples_root / rel).read_text(encoding="utf-8")
     resp = c.post(
         "/api/file-metadata",
@@ -108,7 +97,7 @@ def test_file_metadata_proof_resolves_theorem_with_export_rename(examples_client
     body = resp.get_json()
     theorem = body.get("theorem_details")
     assert theorem is not None
-    assert theorem["name"] == "MultiKeyPRFSecurity"
+    assert theorem["name"] == "PRFSecurity_MultiKey"
     assert "Real" in theorem["sides"]
     assert "Random" in theorem["sides"]
 
@@ -192,9 +181,9 @@ def test_check_endpoint_reports_failure(examples_client):
 
 def test_inlined_game_endpoint(examples_client):
     c, examples_root = examples_client
-    rel = "Proofs/PRG/TriplingPRGSecure.proof"
+    rel = "Proofs/PRG/TriplingPRG_PRGSecurity.proof"
     content = (examples_root / rel).read_text(encoding="utf-8")
-    step_text = "Security(T).Real against Security(T).Adversary"
+    step_text = "PRGSecurity(T).Real against PRGSecurity(T).Adversary"
     resp = c.post(
         "/api/inlined-game",
         data=json.dumps(
@@ -215,7 +204,7 @@ def test_inlined_game_endpoint_with_reduction_reference(examples_client):
     minimal-proof builder skipped Reduction blocks and the user got an
     `Error: \\`R_DDH'` parser failure."""
     c, examples_root = examples_client
-    rel = "Proofs/Group/DDHMultiChalImpliesHashedDDHMultiChal.proof"
+    rel = "Proofs/Group/DDHMultiChal_implies_HashedDDHMultiChal.proof"
     content = (examples_root / rel).read_text(encoding="utf-8")
     step_text = (
         "DDHMultiChal(G).Left compose R_DDH(G, n, H)"
@@ -237,7 +226,7 @@ def test_inlined_game_endpoint_with_reduction_reference(examples_client):
 
 def test_inlined_game_endpoint_missing_step_text(examples_client):
     c, examples_root = examples_client
-    rel = "Proofs/PRG/TriplingPRGSecure.proof"
+    rel = "Proofs/PRG/TriplingPRG_PRGSecurity.proof"
     content = (examples_root / rel).read_text(encoding="utf-8")
     resp = c.post(
         "/api/inlined-game",

--- a/tests/unit/engine/test_canonicalization_trace.py
+++ b/tests/unit/engine/test_canonicalization_trace.py
@@ -15,7 +15,7 @@ from proof_frog.web_server import (
 REPO_ROOT = Path(__file__).parent.parent.parent.parent
 EXAMPLES = REPO_ROOT / "examples"
 # A simple proof with multiple steps that all pass
-PROOF_PATH = str(EXAMPLES / "Proofs" / "SymEnc" / "OTUCimpliesOTS.proof")
+PROOF_PATH = str(EXAMPLES / "Proofs" / "SymEnc" / "INDOT$_implies_INDOT.proof")
 
 
 # -- canonicalize_game_with_trace -------------------------------------------

--- a/tests/unit/other/test_describe.py
+++ b/tests/unit/other/test_describe.py
@@ -48,26 +48,26 @@ class TestDescribeScheme:
 
 class TestDescribeGame:
     def test_onetimesecrecy_structure(self) -> None:
-        out = describe_file(str(EXAMPLES / "Games/SymEnc/OneTimeSecrecy.game"))
-        assert "GameFile (export as: OneTimeSecrecy)" in out
+        out = describe_file(str(EXAMPLES / "Games/SymEnc/INDOT.game"))
+        assert "GameFile (export as: INDOT)" in out
         assert "Game Left" in out
         assert "Game Right" in out
         assert "Eavesdrop" in out
 
     def test_both_games_present(self) -> None:
-        out = describe_file(str(EXAMPLES / "Games/SymEnc/OneTimeSecrecy.game"))
+        out = describe_file(str(EXAMPLES / "Games/SymEnc/INDOT.game"))
         lines = out.splitlines()
         game_lines = [l for l in lines if l.startswith("Game ")]
         assert len(game_lines) == 2
 
     def test_no_implementations(self) -> None:
-        out = describe_file(str(EXAMPLES / "Games/SymEnc/OneTimeSecrecy.game"))
+        out = describe_file(str(EXAMPLES / "Games/SymEnc/INDOT.game"))
         assert "return" not in out
 
 
 class TestDescribeProof:
     def test_proof_structure(self) -> None:
-        out = describe_file(str(EXAMPLES / "Proofs/SymEnc/OTUCimpliesOTS.proof"))
+        out = describe_file(str(EXAMPLES / "Proofs/SymEnc/INDOT$_implies_INDOT.proof"))
         assert "Proof:" in out
         assert "Let:" in out
         assert "Assume:" in out
@@ -75,11 +75,11 @@ class TestDescribeProof:
         assert "Games:" in out
 
     def test_theorem_present(self) -> None:
-        out = describe_file(str(EXAMPLES / "Proofs/SymEnc/OTUCimpliesOTS.proof"))
-        assert "OneTimeSecrecy" in out
+        out = describe_file(str(EXAMPLES / "Proofs/SymEnc/INDOT$_implies_INDOT.proof"))
+        assert "INDOT" in out
 
     def test_game_hops_listed(self) -> None:
-        out = describe_file(str(EXAMPLES / "Proofs/SymEnc/OTUCimpliesOTS.proof"))
+        out = describe_file(str(EXAMPLES / "Proofs/SymEnc/INDOT$_implies_INDOT.proof"))
         # Should list at least the first and last game steps
         assert "Left" in out
         assert "Right" in out

--- a/tests/unit/test_diagnostics_integration.py
+++ b/tests/unit/test_diagnostics_integration.py
@@ -25,7 +25,7 @@ def _run_prove_json(proof_path: str, cwd: Path = REPO_ROOT) -> dict:
 
 def test_passing_proof_has_null_diagnosis() -> None:
     """A passing proof should have hop_results where every diagnosis is null."""
-    proof_path = "examples/Proofs/SymEnc/ModOTPSecure.proof"
+    proof_path = "examples/Proofs/SymEnc/ModOTP_INDOT.proof"
     data = _run_prove_json(proof_path)
 
     assert data["success"] is True


### PR DESCRIPTION
Update hardcoded example paths in tests to reflect the renamed game, scheme, and proof files in the examples submodule. Also update export-name assertions (e.g., OneTimeSecrecy → INDOT, MultiKeyPRFSecurity → PRFSecurity_MultiKey, CPA → INDCPA_MultiChal).