### PR TITLE
Add help button and website links to web editor

### DIFF
--- a/proof_frog/web/app.js
+++ b/proof_frog/web/app.js
@@ -150,6 +150,57 @@ document.getElementById("output-close").addEventListener("click", () => {
   document.getElementById("output-pane").classList.remove("visible");
 });
 btnTheme.addEventListener("click", () => applyTheme(!state.darkMode));
+
+// ── Help menu ────────────────────────────────────────────────────────────────
+const btnHelp = document.getElementById("btn-help");
+const helpMenu = document.getElementById("help-menu");
+btnHelp.addEventListener("click", (e) => {
+  e.stopPropagation();
+  updateHelpContext();
+  helpMenu.classList.toggle("open");
+});
+document.addEventListener("click", (e) => {
+  if (!helpMenu.contains(e.target) && e.target !== btnHelp) {
+    helpMenu.classList.remove("open");
+  }
+});
+
+const HELP_FILE_TYPES = {
+  ".primitive": {
+    heading: "Primitives",
+    label: "Primitives Reference",
+    url: "https://prooffrog.github.io/manual/language-reference/primitives",
+  },
+  ".scheme": {
+    heading: "Schemes",
+    label: "Schemes Reference",
+    url: "https://prooffrog.github.io/manual/language-reference/schemes",
+  },
+  ".game": {
+    heading: "Games",
+    label: "Games Reference",
+    url: "https://prooffrog.github.io/manual/language-reference/games",
+  },
+  ".proof": {
+    heading: "Proofs",
+    label: "Proofs Reference",
+    url: "https://prooffrog.github.io/manual/language-reference/proofs",
+  },
+};
+function updateHelpContext() {
+  const section = document.getElementById("help-context-section");
+  const heading = document.getElementById("help-context-heading");
+  const link = document.getElementById("help-context-link");
+  const tab = state.activeTab;
+  if (!tab) { section.style.display = "none"; return; }
+  const ext = Object.keys(HELP_FILE_TYPES).find(e => tab.endsWith(e));
+  if (!ext) { section.style.display = "none"; return; }
+  const info = HELP_FILE_TYPES[ext];
+  section.style.display = "";
+  heading.textContent = info.heading;
+  link.textContent = info.label;
+  link.href = info.url;
+}
 document.getElementById("btn-collapse-all").addEventListener("click", collapseAll);
 document.getElementById("btn-expand-all").addEventListener("click", expandAll);
 

--- a/proof_frog/web/index.html
+++ b/proof_frog/web/index.html
@@ -73,8 +73,31 @@
     <span class="spacer"></span>
     <span class="dir-label" id="dir-label"></span>
 
-    <div class="toolbar-divider"></div>
-
+    <div class="help-dropdown">
+      <button id="btn-help" class="icon-only" title="Help">
+        <svg class="toolbar-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/><path d="M5.255 5.786a.237.237 0 0 0 .241.247h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286zm1.557 5.763c0 .533.425.927 1.01.927.609 0 1.028-.394 1.028-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94z"/></svg>
+      </button>
+      <div id="help-menu" class="help-menu">
+        <div class="help-menu-section">
+          <div class="help-menu-heading">ProofFrog</div>
+          <a href="https://prooffrog.github.io" target="_blank" rel="noopener">Website</a>
+          <a href="https://prooffrog.github.io/manual/" target="_blank" rel="noopener">Manual</a>
+          <a href="https://prooffrog.github.io/manual/web-editor" target="_blank" rel="noopener">Web Editor Guide</a>
+        </div>
+        <div class="help-menu-section" id="help-context-section" style="display:none">
+          <div class="help-menu-heading" id="help-context-heading">File Reference</div>
+          <a id="help-context-link" href="#" target="_blank" rel="noopener">Language Reference</a>
+        </div>
+        <div class="help-menu-section">
+          <div class="help-menu-heading">Reference</div>
+          <a href="https://prooffrog.github.io/manual/language-reference/" target="_blank" rel="noopener">Language Reference</a>
+          <a href="https://prooffrog.github.io/manual/tutorial/" target="_blank" rel="noopener">Tutorial</a>
+          <a href="https://prooffrog.github.io/manual/worked-examples/" target="_blank" rel="noopener">Worked Examples</a>
+          <a href="https://prooffrog.github.io/manual/canonicalization" target="_blank" rel="noopener">Canonicalization</a>
+          <a href="https://prooffrog.github.io/manual/troubleshooting" target="_blank" rel="noopener">Troubleshooting</a>
+        </div>
+      </div>
+    </div>
     <button id="btn-theme" class="icon-only" title="Toggle light/dark mode">
       <svg id="theme-icon-dark" class="toolbar-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor"><path d="M6 .278a.77.77 0 0 1 .08.858 7.2 7.2 0 0 0-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.78.78 0 0 1 .81.316.73.73 0 0 1-.031.893A8.35 8.35 0 0 1 8.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.75.75 0 0 1 6 .278z"/></svg>
       <svg id="theme-icon-light" class="toolbar-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" style="display:none"><path d="M8 11a3 3 0 1 1 0-6 3 3 0 0 1 0 6zm0 1a4 4 0 1 0 0-8 4 4 0 0 0 0 8zM8 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 0zm0 13a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0v-2A.5.5 0 0 1 8 13zm8-5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2a.5.5 0 0 1 .5.5zM3 8a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1 0-1h2A.5.5 0 0 1 3 8zm10.657-5.657a.5.5 0 0 1 0 .707l-1.414 1.415a.5.5 0 1 1-.707-.708l1.414-1.414a.5.5 0 0 1 .707 0zm-9.193 9.193a.5.5 0 0 1 0 .707L3.05 13.657a.5.5 0 0 1-.707-.707l1.414-1.414a.5.5 0 0 1 .707 0zm9.193 2.121a.5.5 0 0 1-.707 0l-1.414-1.414a.5.5 0 0 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .707zM4.464 4.465a.5.5 0 0 1-.707 0L2.343 3.05a.5.5 0 1 1 .707-.707l1.414 1.414a.5.5 0 0 1 0 .708z"/></svg>
@@ -98,6 +121,12 @@
           <img src="/prooffrog.png" alt="ProofFrog">
           <h2>ProofFrog</h2>
           <p>Select a file from the explorer to start editing.</p>
+          <div class="welcome-links">
+            <a href="https://prooffrog.github.io" target="_blank" rel="noopener">Website</a>
+            <a href="https://prooffrog.github.io/manual/" target="_blank" rel="noopener">Manual</a>
+            <a href="https://prooffrog.github.io/manual/tutorial/" target="_blank" rel="noopener">Tutorial</a>
+            <a href="https://prooffrog.github.io/manual/language-reference/" target="_blank" rel="noopener">Language Reference</a>
+          </div>
         </div>
       </div>
       <div id="resize-handle"></div>

--- a/proof_frog/web/style.css
+++ b/proof_frog/web/style.css
@@ -68,7 +68,7 @@ html, body { height: 100%; background: var(--bg); color: var(--text); font-famil
   flex-shrink: 0;
 }
 #toolbar .spacer { flex: 1; }
-#toolbar .dir-label { color: var(--text-dim); font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 300px; }
+#toolbar .dir-label { display: none; }
 #toolbar .toolbar-group { display: flex; gap: 6px; align-items: center; flex-shrink: 0; }
 #toolbar .toolbar-divider {
   width: 1px; background: var(--border); align-self: center;
@@ -518,6 +518,35 @@ select.wizard-input { cursor: pointer; }
 #welcome.hidden { display: none; }
 #welcome h2 { font-size: 22px; color: var(--accent); font-weight: 300; }
 #welcome p { font-size: 13px; }
+#welcome .welcome-links {
+  display: flex; gap: 16px; margin-top: 8px; pointer-events: auto;
+}
+#welcome .welcome-links a {
+  color: var(--accent); font-size: 13px; text-decoration: none;
+  border-bottom: 1px solid transparent; transition: border-color 0.15s;
+}
+#welcome .welcome-links a:hover { border-bottom-color: var(--accent); }
+
+/* ── Help dropdown ── */
+.help-dropdown { position: relative; }
+.help-menu {
+  display: none; position: absolute; right: 0; top: 100%; margin-top: 4px;
+  background: var(--bg2); border: 1px solid var(--border); border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15); min-width: 200px; z-index: 1000;
+  padding: 4px 0;
+}
+.help-menu.open { display: block; }
+.help-menu-section { padding: 4px 0; }
+.help-menu-section + .help-menu-section { border-top: 1px solid var(--border); }
+.help-menu-heading {
+  padding: 4px 12px; font-size: 11px; font-weight: 600;
+  color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.5px;
+}
+.help-menu a {
+  display: block; padding: 4px 12px; font-size: 12px;
+  color: var(--text); text-decoration: none; transition: background 0.1s;
+}
+.help-menu a:hover { background: var(--bg3); color: var(--accent); }
 
 /* ── Resize handle ── */
 #resize-handle {


### PR DESCRIPTION
Add a help dropdown menu to the toolbar with links to the ProofFrog website, manual, and context-sensitive links to the relevant language reference page based on the active file type (.primitive, .scheme, .game, .proof). Add quick-start links to the welcome screen. Hide the directory label from the toolbar.

Fixes #185.