### PR TITLE
Fix _resolve_type_alias not handling Tuple-of-types

### DIFF
--- a/proof_frog/semantic_analysis.py
+++ b/proof_frog/semantic_analysis.py
@@ -962,6 +962,22 @@ class CheckTypeVisitor(VariableTypeVisitor):
                 else:
                     resolved_types.append(sub)
             return frog_ast.ProductType(resolved_types)
+        # Tuple-of-types can appear in type positions after parameter
+        # substitution (e.g., Set D = [T1, T2] parsed as Tuple in
+        # expression position).  Resolve elements and normalize to
+        # ProductType so FieldAccess aliases inside are resolved.
+        if isinstance(t, frog_ast.Tuple) and all(
+            isinstance(v, frog_ast.Type) for v in t.values
+        ):
+            resolved_types_t: list[frog_ast.Type] = []
+            for sub in t.values:
+                resolved_sub = self._resolve_type_alias(sub, _seen)
+                if isinstance(resolved_sub, frog_ast.Type):
+                    resolved_types_t.append(resolved_sub)
+                else:
+                    assert isinstance(sub, frog_ast.Type)
+                    resolved_types_t.append(sub)
+            return frog_ast.ProductType(resolved_types_t)
         if isinstance(t, frog_ast.OptionalType):
             resolved_inner = self._resolve_type_alias(t.the_type, _seen)
             if isinstance(resolved_inner, frog_ast.Type):

--- a/tests/unit/typechecking/test_resolve_tuple_alias.py
+++ b/tests/unit/typechecking/test_resolve_tuple_alias.py
@@ -1,0 +1,71 @@
+"""Tests for _resolve_type_alias handling of Tuple-of-types.
+
+Regression test for the bug where a Tuple containing FieldAccess elements
+(e.g., K.SharedSecret) was not resolved by _resolve_type_alias, causing
+type mismatches against the equivalent ProductType whose elements were
+resolved (e.g., Variable("SharedSecretSpace")).
+"""
+
+from proof_frog import frog_ast, semantic_analysis, visitors
+
+
+def _make_visitor_with_kem() -> semantic_analysis.CheckTypeVisitor:
+    """Create a CheckTypeVisitor that knows about a KEM-like primitive K."""
+    kem_members: dict[str, frog_ast.ASTNode] = {
+        "SharedSecret": frog_ast.Variable("SharedSecretSpace"),
+        "Ciphertext": frog_ast.Variable("CiphertextSpace"),
+    }
+    kem_type = visitors.InstantiableType("K", kem_members, "KEM")
+    visitor = semantic_analysis.CheckTypeVisitor({}, "test", {})
+    visitor.variable_type_map_stack[-1]["K"] = kem_type
+    return visitor
+
+
+class TestResolveTupleAlias:
+    """_resolve_type_alias should resolve Tuple-of-types like ProductType."""
+
+    def test_tuple_field_access_resolved(self) -> None:
+        """Tuple([Int, K.SharedSecret]) resolves to ProductType([Int, SharedSecretSpace])."""
+        visitor = _make_visitor_with_kem()
+        t = frog_ast.Tuple([
+            frog_ast.IntType(),
+            frog_ast.FieldAccess(frog_ast.Variable("K"), "SharedSecret"),
+        ])
+        resolved = visitor._resolve_type_alias(t)
+        assert isinstance(resolved, frog_ast.ProductType)
+        assert len(resolved.types) == 2
+        assert resolved.types[0] == frog_ast.IntType()
+        assert resolved.types[1] == frog_ast.Variable("SharedSecretSpace")
+
+    def test_tuple_without_field_access_normalizes(self) -> None:
+        """Tuple([Int, Bool]) normalizes to ProductType([Int, Bool])."""
+        visitor = _make_visitor_with_kem()
+        t = frog_ast.Tuple([frog_ast.IntType(), frog_ast.BoolType()])
+        resolved = visitor._resolve_type_alias(t)
+        assert isinstance(resolved, frog_ast.ProductType)
+        assert resolved.types == [frog_ast.IntType(), frog_ast.BoolType()]
+
+    def test_product_type_field_access_resolved(self) -> None:
+        """ProductType with FieldAccess also resolves (existing behavior)."""
+        visitor = _make_visitor_with_kem()
+        t = frog_ast.ProductType([
+            frog_ast.IntType(),
+            frog_ast.FieldAccess(frog_ast.Variable("K"), "SharedSecret"),
+        ])
+        resolved = visitor._resolve_type_alias(t)
+        assert isinstance(resolved, frog_ast.ProductType)
+        assert resolved.types[1] == frog_ast.Variable("SharedSecretSpace")
+
+    def test_check_types_tuple_vs_product_with_alias(self) -> None:
+        """check_types matches Tuple([..., K.SharedSecret]) against ProductType([..., SharedSecretSpace])."""
+        visitor = _make_visitor_with_kem()
+        product = frog_ast.ProductType([
+            frog_ast.IntType(),
+            frog_ast.Variable("SharedSecretSpace"),
+        ])
+        tuple_t = frog_ast.Tuple([
+            frog_ast.IntType(),
+            frog_ast.FieldAccess(frog_ast.Variable("K"), "SharedSecret"),
+        ])
+        assert visitor.check_types(product, tuple_t)
+        assert visitor.check_types(tuple_t, product)


### PR DESCRIPTION
When a game parameter (e.g., Set D) is substituted with a tuple argument from expression position, the parser creates a Tuple node rather than a ProductType. _resolve_type_alias had no handler for Tuple, so FieldAccess nodes inside (like K.SharedSecret) were never resolved, causing false type mismatches when compared against the equivalent ProductType whose elements were properly resolved.

Add a Tuple case to _resolve_type_alias that resolves each element and normalizes to ProductType, consistent with the existing ProductType handler and with compare_types' Tuple normalization.