### PR TITLE
Make early-return guards a reorder barrier in dependency graph

### DIFF
--- a/proof_frog/dependencies.py
+++ b/proof_frog/dependencies.py
@@ -18,26 +18,47 @@ def generate_dependency_graph(
     def add_dependency(node_in_graph: Node, statement: frog_ast.Statement) -> None:
         node_in_graph.add_neighbour(dependency_graph.get_node(statement))
 
+    field_names = [field.name for field in fields]
+
+    def contains_return(node: frog_ast.ASTNode) -> bool:
+        return isinstance(node, frog_ast.ReturnStatement)
+
+    def mutates_field(stmt: frog_ast.Statement) -> bool:
+        if not isinstance(
+            stmt, (frog_ast.Sample, frog_ast.Assignment, frog_ast.UniqueSample)
+        ):
+            return False
+        target = stmt.var
+        if isinstance(target, frog_ast.Variable):
+            return target.name in field_names
+        if isinstance(target, frog_ast.ArrayAccess) and isinstance(
+            target.the_array, frog_ast.Variable
+        ):
+            return target.the_array.name in field_names
+        return False
+
     for index, statement in enumerate(block.statements):
         node_in_graph = dependency_graph.get_node(statement)
         earlier_statements = list(block.statements[:index])
         earlier_statements.reverse()
 
-        def contains_return(node: frog_ast.ASTNode) -> bool:
-            return isinstance(node, frog_ast.ReturnStatement)
-
         if visitors.SearchVisitor(contains_return).visit(statement):
             for preceding_statement in block.statements[:index]:
                 if (
-                    isinstance(
-                        preceding_statement,
-                        (frog_ast.Sample, frog_ast.Assignment, frog_ast.UniqueSample),
+                    mutates_field(preceding_statement)
+                    or visitors.SearchVisitor(contains_return).visit(
+                        preceding_statement
                     )
-                    and isinstance(preceding_statement.var, frog_ast.Variable)
-                    and preceding_statement.var.name in [field.name for field in fields]
-                ) or visitors.SearchVisitor(contains_return).visit(
-                    preceding_statement
-                ) is not None:
+                    is not None
+                ):
+                    add_dependency(node_in_graph, preceding_statement)
+
+        if mutates_field(statement):
+            for preceding_statement in block.statements[:index]:
+                if (
+                    visitors.SearchVisitor(contains_return).visit(preceding_statement)
+                    is not None
+                ):
                     add_dependency(node_in_graph, preceding_statement)
 
         variables = visitors.VariableCollectionVisitor().visit(statement)

--- a/tests/unit/engine/test_non_interchangeable.py
+++ b/tests/unit/engine/test_non_interchangeable.py
@@ -92,3 +92,72 @@ def test_exercise_2_26a_double_ciphertext_not_ror() -> None:
         "Exercise 2.26a: c||c should NOT be interchangeable with uniform "
         "— the two halves are always equal"
     )
+
+
+def test_early_return_guard_is_a_reorder_barrier() -> None:
+    """A side-effecting assignment must not be reordered past an early
+    return inside an if-statement.
+
+    Left:  on z == target, returns ssStar without modifying T.
+           Repeated calls always return ssStar.
+    Right: on z == target, inserts T[z] = h FIRST then returns ssStar.
+           Repeated calls return T[z] = h, not ssStar.
+
+    These games are observably distinct (the adversary can call Hash(z)
+    twice on the same z and compare the results). Canonicalizing them
+    to the same form would be unsound.
+    """
+    left = frog_parser.parse_game("""
+    Game Left() {
+        BitString<8> ssStar;
+        BitString<8> target;
+        Map<BitString<8>, BitString<8>> T;
+
+        Void Initialize() {
+            ssStar <- BitString<8>;
+            target <- BitString<8>;
+        }
+
+        BitString<8> Hash(BitString<8> z) {
+            if (z in T) {
+                return T[z];
+            }
+            if (z == target) {
+                return ssStar;
+            }
+            BitString<8> h <- BitString<8>;
+            T[z] = h;
+            return h;
+        }
+    }
+    """)
+    right = frog_parser.parse_game("""
+    Game Right() {
+        BitString<8> ssStar;
+        BitString<8> target;
+        Map<BitString<8>, BitString<8>> T;
+
+        Void Initialize() {
+            ssStar <- BitString<8>;
+            target <- BitString<8>;
+        }
+
+        BitString<8> Hash(BitString<8> z) {
+            if (z in T) {
+                return T[z];
+            }
+            BitString<8> h <- BitString<8>;
+            T[z] = h;
+            if (z == target) {
+                return ssStar;
+            }
+            return h;
+        }
+    }
+    """)
+    engine = _make_engine()
+    assert engine.canonicalize_game(left) != engine.canonicalize_game(right), (
+        "Topological sort must not reorder T[z] = h past the early-return "
+        "guard `if (z == target) return ssStar;` — doing so changes the "
+        "observable behavior on a second Hash query at the same z."
+    )


### PR DESCRIPTION
The dependency graph used by ProofEngine.sort_block (topological sort) modeled return-containing statements as depending on preceding field writes, but lacked the symmetric direction: a field-mutating statement that follows an `if (...) return ...;` had no edge constraining it to stay after the guard. As a result, topological sort could hoist a state mutation past an early-return barrier, producing canonical forms whose cross-invocation behavior differed from the source. An adversary calling the same oracle twice on the same input could distinguish.

Two changes in dependencies.generate_dependency_graph:

1. Add a `mutates_field` helper that recognizes both direct field assignment (`T = ...`) and writes into a map/array field (`T[k] = ...`). The previous field-write check was an `isinstance(stmt.var, Variable)` test that missed `ArrayAccess` targets entirely. The helper is reused in both edge directions, simultaneously closing a latent gap in the existing "return-containing depends on preceding field-mutating" edge.

2. Add a new dep-graph edge: any statement that mutates a field depends on every preceding statement that contains a return. This forces topological sort to keep field mutations after any `if` whose body returns.

Discovered via the Lazy-ROM CCA case study, where a reduction's lazy- table-with-cross-scan Hash body had a Solve-guarded short-circuit that the engine was reordering past the lazy insert.

Regression test: test_early_return_guard_is_a_reorder_barrier in tests/unit/engine/test_non_interchangeable.py constructs a minimal Left/Right pair (mutation-then-guard vs. guard-then-mutation) and asserts they canonicalize to distinct forms.