### PR TITLE
Release VSCode extension 0.1.1 with highlighting for requires clause

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -6,7 +6,7 @@ This VSCode extension provides language support for ProofFrog's domain-specific 
 
 ## About ProofFrog
 
-ProofFrog checks the validity of game hops for cryptographic game-hopping proofs in the reduction-based security paradigm: it checks that the starting and ending games match the security definition, and that each adjacent pair of games is either interchangeable (by code equivalence) or justified by a stated assumption. Proofs are written in FrogLang, a small C/Java-style domain-specific language designed to look like a pen-and-paper proof. ProofFrog can be used from the command line, a browser-based editor, or an MCP server for integration with AI coding assistants. ProofFrog is suitable for introductory level proofs, but is not as expressive for advanced concepts as other verification tools like EasyCrypt.
+ProofFrog checks the validity of game hops for cryptographic game-hopping proofs in the reduction-based security paradigm: it checks that the starting and ending games match the security definition, and that each adjacent pair of games is either interchangeable (by code equivalence) or justified by a stated assumption. Proofs are written in FrogLang, a small C/Java-style domain-specific language designed to look like a pen-and-paper proof. ProofFrog can be used from the command line, a browser-based editor, or an MCP server for integration with AI coding assistants. ProofFrog is suitable for introductory-level proofs, but is not as expressive for advanced concepts as other verification tools like EasyCrypt and lacks comparable levels of assurance.
 
 ## Features
 

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prooffrog",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prooffrog",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "vscode-languageclient": "^9.0.1"

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "prooffrog",
   "displayName": "ProofFrog",
   "description": "Language support for ProofFrog's FrogLang cryptographic proof DSL",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "publisher": "ProofFrog",
   "license": "MIT",
   "icon": "prooffrog.png",

--- a/vscode-extension/syntaxes/prooffrog.tmLanguage.json
+++ b/vscode-extension/syntaxes/prooffrog.tmLanguage.json
@@ -64,7 +64,7 @@
         },
         {
           "name": "keyword.proof.prooffrog",
-          "match": "\\b(proof|assume|theorem|games|let|induction|from|against|compose|lemma|by)\\b"
+          "match": "\\b(proof|assume|theorem|games|let|induction|from|against|compose|lemma|by|is|prime)\\b"
         },
         {
           "name": "keyword.other.prooffrog",


### PR DESCRIPTION
Add `is` and `prime` to the syntax grammar so the new `requires: q is prime;` proof section highlights fully, and bump the extension to 0.1.1.